### PR TITLE
:bug: Validate SHA sum for JSON manifest file

### DIFF
--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -256,7 +256,7 @@ func validateShaSums(sums *core.Sha256Sums) error {
 
 func validateShaSumsEntry(path string, checksum []byte) error {
 	binaryName := filepath.Base(path)
-	if !regexp.MustCompile("^terraform-provider-.+_.+_.+.zip$").MatchString(binaryName) {
+	if !regexp.MustCompile("^terraform-provider-.+_.+_.+.(zip|json)$").MatchString(binaryName) {
 		return fmt.Errorf("provider binary %s file name is invalid", binaryName)
 	}
 


### PR DESCRIPTION
Hello guys 👋

My SHA256SUMS also contains a sha for the manifest.json :  
![image](https://github.com/boring-registry/boring-registry/assets/234101/1a9e6f56-4597-4513-a8ec-821fb1954e6e)

But when i try to upload my provider, sha validation fail because of the json file (which have a valid sha by the way):  
![image](https://github.com/boring-registry/boring-registry/assets/234101/8832cefa-1fdf-4cb7-93d5-bb31fef89f8e)

So i've just added the json extension in the regex (instead of allowing all type of files).
