### PR TITLE
fix(upload): upload module inherits flags from upload

### DIFF
--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -54,11 +54,11 @@ func init() {
 	}
 	uploadCmd.AddCommand(uploadModuleCmd, uploadProviderCmd)
 
-	uploadCmd.Flags().BoolVar(&flagRecursive, "recursive", true, "Recursively traverse <dir> and upload all modules in subdirectories")
-	uploadCmd.Flags().BoolVar(&flagIgnoreExistingModule, "ignore-existing", true, "Ignore already existing modules. If set to false upload will fail immediately if a module already exists in that version")
-	uploadCmd.Flags().StringVar(&flagVersionConstraintsRegex, "version-constraints-regex", "", `Limit the module versions that are eligible for upload with a regex that a version has to match.
+	uploadCmd.PersistentFlags().BoolVar(&flagRecursive, "recursive", true, "Recursively traverse <dir> and upload all modules in subdirectories")
+	uploadCmd.PersistentFlags().BoolVar(&flagIgnoreExistingModule, "ignore-existing", true, "Ignore already existing modules. If set to false upload will fail immediately if a module already exists in that version")
+	uploadCmd.PersistentFlags().StringVar(&flagVersionConstraintsRegex, "version-constraints-regex", "", `Limit the module versions that are eligible for upload with a regex that a version has to match.
 Can be combined with the -version-constraints-semver flag`)
-	uploadCmd.Flags().StringVar(&flagVersionConstraintsSemver, "version-constraints-semver", "", `Limit the module versions that are eligible for upload with version constraints.
+	uploadCmd.PersistentFlags().StringVar(&flagVersionConstraintsSemver, "version-constraints-semver", "", `Limit the module versions that are eligible for upload with version constraints.
 The version string has to be formatted as a string literal containing one or more conditions, which are separated by commas.
 Can be combined with the -version-constrained-regex flag`)
 }


### PR DESCRIPTION
`boring-registry upload` is an alias for the `boring-registry upload module` command. Unfortunately, the flags from `upload` were not available to `upload module`.
This PR attaches the flags to a persistent flagset, so that the child command inherits the flags from the parent properly.