### PR TITLE
feat: Adding more metrics

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -281,11 +281,11 @@ func serveMux(ctx context.Context) (*http.ServeMux, error) {
 		return nil, err
 	}
 
-	if err := registerModule(mux, s, metrics.Modules, instrumentation); err != nil {
+	if err := registerModule(mux, s, metrics.Module, instrumentation); err != nil {
 		return nil, err
 	}
 
-	if err := registerProvider(mux, s, metrics.Providers, instrumentation); err != nil {
+	if err := registerProvider(mux, s, metrics.Provider, instrumentation); err != nil {
 		return nil, err
 	}
 
@@ -298,7 +298,7 @@ func serveMux(ctx context.Context) (*http.ServeMux, error) {
 			svc = mirror.NewMirror(s)
 		}
 
-		if err := registerMirror(mux, s, svc, metrics.Mirrors, instrumentation); err != nil {
+		if err := registerMirror(mux, s, svc, metrics.Mirror, instrumentation); err != nil {
 			return nil, err
 		}
 	}
@@ -320,7 +320,7 @@ func registerMetrics(mux *http.ServeMux) {
 	mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
 }
 
-func registerModule(mux *http.ServeMux, s storage.Storage, metrics *o11y.ModulesMetrics, instrumentation o11y.Middleware) error {
+func registerModule(mux *http.ServeMux, s storage.Storage, metrics *o11y.ModuleMetrics, instrumentation o11y.Middleware) error {
 	service := module.NewService(s)
 	{
 		service = module.LoggingMiddleware()(service)
@@ -364,7 +364,7 @@ func authMiddleware() endpoint.Middleware {
 	return auth.Middleware(providers...)
 }
 
-func registerProvider(mux *http.ServeMux, s storage.Storage, metrics *o11y.ProvidersMetrics, instrumentation o11y.Middleware) error {
+func registerProvider(mux *http.ServeMux, s storage.Storage, metrics *o11y.ProviderMetrics, instrumentation o11y.Middleware) error {
 	service := provider.NewService(s)
 	{
 		service = provider.LoggingMiddleware()(service)

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.19.1
 	github.com/okta/okta-jwt-verifier-golang/v2 v2.0.3
-	github.com/prometheus/client_golang v1.18.0
+	github.com/prometheus/client_golang v1.19.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
@@ -85,7 +85,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
-	github.com/prometheus/common v0.46.0 // indirect
+	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -255,6 +255,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.18.0 h1:HzFfmkOzH5Q8L8G+kSJKUx5dtG87sewO+FoDDqP5Tbk=
 github.com/prometheus/client_golang v1.18.0/go.mod h1:T+GXkCk5wSJyOqMIzVgvvjFDlkOQntgjkJWKrN5txjA=
+github.com/prometheus/client_golang v1.19.0 h1:ygXvpU1AoN1MhdzckN+PyD9QJOSD4x7kmXYlnfbA6JU=
+github.com/prometheus/client_golang v1.19.0/go.mod h1:ZRM9uEAypZakd+q/x7+gmsvXdURP+DABIEIjnmDdp+k=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.5.0 h1:VQw1hfvPvk3Uv6Qf29VrPF32JB6rtbgI6cYPYQjL0Qw=
 github.com/prometheus/client_model v0.5.0/go.mod h1:dTiFglRmd66nLR9Pv9f0mZi7B7fk5Pm3gvsjB5tr+kI=
@@ -262,6 +264,8 @@ github.com/prometheus/common v0.45.0 h1:2BGz0eBc2hdMDLnO/8n0jeB3oPrt2D08CekT0lne
 github.com/prometheus/common v0.45.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGyv9MZjVOJsY=
 github.com/prometheus/common v0.46.0 h1:doXzt5ybi1HBKpsZOL0sSkaNHJJqkyfEWZGGqqScV0Y=
 github.com/prometheus/common v0.46.0/go.mod h1:Tp0qkxpb9Jsg54QMe+EAmqXkSV7Evdy1BTn+g2pa/hQ=
+github.com/prometheus/common v0.48.0 h1:QO8U2CdOzSn1BBsmXJXduaaW+dY/5QLjfB8svtSzKKE=
+github.com/prometheus/common v0.48.0/go.mod h1:0/KsvlIEfPQCQ5I2iNSAWKPZziNCvRs5EC6ILDTlAPc=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=

--- a/pkg/mirror/endpoint.go
+++ b/pkg/mirror/endpoint.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/boring-registry/boring-registry/pkg/core"
 	o11y "github.com/boring-registry/boring-registry/pkg/observability"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/go-kit/kit/endpoint"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type listProviderVersionsRequest struct {
@@ -37,9 +37,9 @@ func listProviderVersionsEndpoint(svc Service, metrics *o11y.MirrorMetrics) endp
 		}
 
 		metrics.ListProviderVersions.With(prometheus.Labels{
-			"hostname":  req.Hostname,
-			"namespace": req.Namespace,
-			"name":      req.Name,
+			o11y.HostnameLabel:  req.Hostname,
+			o11y.NamespaceLabel: req.Namespace,
+			o11y.NameLabel:      req.Name,
 		}).Inc()
 
 		provider := &core.Provider{
@@ -83,10 +83,10 @@ func listProviderInstallationEndpoint(svc Service, metrics *o11y.MirrorMetrics) 
 		}
 
 		metrics.ListProviderInstallation.With(prometheus.Labels{
-			"hostname":  req.Hostname,
-			"namespace": req.Namespace,
-			"name":      req.Name,
-			"version":   req.Version,
+			o11y.HostnameLabel:  req.Hostname,
+			o11y.NamespaceLabel: req.Namespace,
+			o11y.NameLabel:      req.Name,
+			o11y.VersionLabel:   req.Version,
 		}).Inc()
 
 		provider := &core.Provider{
@@ -128,12 +128,12 @@ func retrieveProviderArchiveEndpoint(svc Service, metrics *o11y.MirrorMetrics) e
 		}
 
 		metrics.RetrieveProviderArchive.With(prometheus.Labels{
-			"hostname":  req.Hostname,
-			"namespace": req.Namespace,
-			"name":      req.Name,
-			"version":   req.Version,
-			"os":        req.OS,
-			"arch":      req.Architecture,
+			o11y.HostnameLabel:  req.Hostname,
+			o11y.NamespaceLabel: req.Namespace,
+			o11y.NameLabel:      req.Name,
+			o11y.VersionLabel:   req.Version,
+			o11y.OsLabel:        req.OS,
+			o11y.ArchLabel:      req.Architecture,
 		}).Inc()
 
 		provider := &core.Provider{

--- a/pkg/mirror/endpoint.go
+++ b/pkg/mirror/endpoint.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 
 	"github.com/boring-registry/boring-registry/pkg/core"
+	o11y "github.com/boring-registry/boring-registry/pkg/observability"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/go-kit/kit/endpoint"
 )
@@ -27,12 +29,18 @@ type ListProviderVersionsResponse struct {
 	mirrorSource
 }
 
-func listProviderVersionsEndpoint(svc Service) endpoint.Endpoint {
+func listProviderVersionsEndpoint(svc Service, metrics *o11y.MirrorMetrics) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(listProviderVersionsRequest)
 		if !ok {
 			return nil, fmt.Errorf("type assertion failed for listProviderVersionsRequest")
 		}
+
+		metrics.ListProviderVersions.With(prometheus.Labels{
+			"hostname":  req.Hostname,
+			"namespace": req.Namespace,
+			"name":      req.Name,
+		}).Inc()
 
 		provider := &core.Provider{
 			Hostname:  req.Hostname,
@@ -67,12 +75,19 @@ type Archive struct {
 	Hashes []string `json:"hashes,omitempty"`
 }
 
-func listProviderInstallationEndpoint(svc Service) endpoint.Endpoint {
+func listProviderInstallationEndpoint(svc Service, metrics *o11y.MirrorMetrics) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(listProviderInstallationRequest)
 		if !ok {
 			return nil, fmt.Errorf("type assertion failed for listProviderInstallationRequest")
 		}
+
+		metrics.ListProviderInstallation.With(prometheus.Labels{
+			"hostname":  req.Hostname,
+			"namespace": req.Namespace,
+			"name":      req.Name,
+			"version":   req.Version,
+		}).Inc()
 
 		provider := &core.Provider{
 			Hostname:  req.Hostname,
@@ -105,12 +120,21 @@ type retrieveProviderArchiveResponse struct {
 	mirrorSource
 }
 
-func retrieveProviderArchiveEndpoint(svc Service) endpoint.Endpoint {
+func retrieveProviderArchiveEndpoint(svc Service, metrics *o11y.MirrorMetrics) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(retrieveProviderArchiveRequest)
 		if !ok {
 			return nil, fmt.Errorf("type assertion failed for retrieveProviderArchiveRequest")
 		}
+
+		metrics.RetrieveProviderArchive.With(prometheus.Labels{
+			"hostname":  req.Hostname,
+			"namespace": req.Namespace,
+			"name":      req.Name,
+			"version":   req.Version,
+			"os":        req.OS,
+			"arch":      req.Architecture,
+		}).Inc()
 
 		provider := &core.Provider{
 			Hostname:  req.Hostname,

--- a/pkg/module/endpoint.go
+++ b/pkg/module/endpoint.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	o11y "github.com/boring-registry/boring-registry/pkg/observability"
+
 	"github.com/go-kit/kit/endpoint"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -26,14 +27,14 @@ type listResponse struct {
 	Modules []listResponseModule `json:"modules,omitempty"`
 }
 
-func listEndpoint(svc Service, metrics *o11y.ModulesMetrics) endpoint.Endpoint {
+func listEndpoint(svc Service, metrics *o11y.ModuleMetrics) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(listRequest)
 
 		metrics.ListVersions.With(prometheus.Labels{
-			"namespace": req.namespace,
-			"name":      req.name,
-			"provider":  req.provider,
+			o11y.NamespaceLabel: req.namespace,
+			o11y.NameLabel:      req.name,
+			o11y.ProviderLabel:  req.provider,
 		}).Inc()
 
 		res, err := svc.ListModuleVersions(ctx, req.namespace, req.name, req.provider)
@@ -68,15 +69,15 @@ type downloadRequest struct {
 
 type downloadResponse struct{ url string }
 
-func downloadEndpoint(svc Service, metrics *o11y.ModulesMetrics) endpoint.Endpoint {
+func downloadEndpoint(svc Service, metrics *o11y.ModuleMetrics) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(downloadRequest)
 
 		metrics.Download.With(prometheus.Labels{
-			"namespace": req.namespace,
-			"name":      req.name,
-			"provider":  req.provider,
-			"version":   req.version,
+			o11y.NamespaceLabel: req.namespace,
+			o11y.NameLabel:      req.name,
+			o11y.ProviderLabel:  req.provider,
+			o11y.VersionLabel:   req.version,
 		}).Inc()
 
 		res, err := svc.GetModule(ctx, req.namespace, req.name, req.provider, req.version)

--- a/pkg/module/transport.go
+++ b/pkg/module/transport.go
@@ -25,7 +25,7 @@ const (
 )
 
 // MakeHandler returns a fully initialized http.Handler.
-func MakeHandler(svc Service, auth endpoint.Middleware, metrics *o11y.ModulesMetrics, instrumentation o11y.Middleware, options ...httptransport.ServerOption) http.Handler {
+func MakeHandler(svc Service, auth endpoint.Middleware, metrics *o11y.ModuleMetrics, instrumentation o11y.Middleware, options ...httptransport.ServerOption) http.Handler {
 	r := mux.NewRouter().StrictSlash(true)
 
 	r.Methods("GET").Path(`/{namespace}/{name}/{provider}/versions`).Handler(

--- a/pkg/observability/metrics.go
+++ b/pkg/observability/metrics.go
@@ -5,22 +5,32 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+const (
+	HostnameLabel  = "hostname"
+	NamespaceLabel = "namespace"
+	NameLabel      = "name"
+	ProviderLabel  = "provider"
+	VersionLabel   = "version"
+	OsLabel        = "os"
+	ArchLabel      = "arch"
+)
+
 type ServerMetrics struct {
-	Mirrors   *MirrorMetrics
-	Modules   *ModulesMetrics
-	Providers *ProvidersMetrics
-	Http      *HttpMetrics
+	Mirror   *MirrorMetrics
+	Module   *ModuleMetrics
+	Provider *ProviderMetrics
+	Http     *HttpMetrics
 }
 type MirrorMetrics struct {
 	ListProviderVersions     *prometheus.CounterVec
 	ListProviderInstallation *prometheus.CounterVec
 	RetrieveProviderArchive  *prometheus.CounterVec
 }
-type ModulesMetrics struct {
+type ModuleMetrics struct {
 	ListVersions *prometheus.CounterVec
 	Download     *prometheus.CounterVec
 }
-type ProvidersMetrics struct {
+type ProviderMetrics struct {
 	ListVersions *prometheus.CounterVec
 	Download     *prometheus.CounterVec
 }
@@ -32,123 +42,123 @@ type HttpMetrics struct {
 }
 
 func NewMetrics(buckets []float64) *ServerMetrics {
-	boring_namespace := "boring_registry"
-	http_namespace := "http"
+	boringNamespace := "boring_registry"
+	httpNamespace := "http"
 
-	mirrors_subsystem := "mirrors"
-	providers_subsystem := "providers"
-	modules_subsystem := "modules"
-	request_subsystem := "request"
-	response_subsystem := "response"
+	mirrorsSubsystem := "mirrors"
+	providersSubsystem := "providers"
+	modulesSubsystem := "modules"
+	requestSubsystem := "request"
+	responseSubsystem := "response"
 
 	if buckets == nil {
-		buckets = prometheus.ExponentialBuckets(0.1, 1.5, 5)
+		buckets = prometheus.ExponentialBuckets(0.05, 1.6, 10)
 	}
 
 	metrics := &ServerMetrics{
-		Mirrors: &MirrorMetrics{
+		Mirror: &MirrorMetrics{
 			ListProviderVersions: promauto.NewCounterVec(
 				prometheus.CounterOpts{
-					Namespace: boring_namespace,
-					Subsystem: mirrors_subsystem,
-					Name:      "list_provider_versions",
-					Help:      "Number providers versions listing on the mirror.",
+					Namespace: boringNamespace,
+					Subsystem: mirrorsSubsystem,
+					Name:      "list_provider_versions_total",
+					Help:      "The total number of provider versions requests by mirror",
 				},
-				[]string{"hostname", "namespace", "name"},
+				[]string{HostnameLabel, NamespaceLabel, NameLabel},
 			),
 			ListProviderInstallation: promauto.NewCounterVec(
 				prometheus.CounterOpts{
-					Namespace: boring_namespace,
-					Subsystem: mirrors_subsystem,
-					Name:      "list_provider_installations",
-					Help:      "Number providers installations listing on the mirror.",
+					Namespace: boringNamespace,
+					Subsystem: mirrorsSubsystem,
+					Name:      "list_provider_installations_total",
+					Help:      "The total number of provider installations requests by mirror",
 				},
-				[]string{"hostname", "namespace", "name", "version"},
+				[]string{HostnameLabel, NamespaceLabel, NameLabel, VersionLabel},
 			),
 			RetrieveProviderArchive: promauto.NewCounterVec(
 				prometheus.CounterOpts{
-					Namespace: boring_namespace,
-					Subsystem: mirrors_subsystem,
-					Name:      "download_version",
-					Help:      "Number providers retreive and archive on the mirror.",
+					Namespace: boringNamespace,
+					Subsystem: mirrorsSubsystem,
+					Name:      "download_version_total",
+					Help:      "The total number of provider retreive requests by mirror",
 				},
-				[]string{"hostname", "namespace", "name", "version", "os", "arch"},
+				[]string{HostnameLabel, NamespaceLabel, NameLabel, VersionLabel, OsLabel, ArchLabel},
 			),
 		},
-		Providers: &ProvidersMetrics{
+		Provider: &ProviderMetrics{
 			ListVersions: promauto.NewCounterVec(
 				prometheus.CounterOpts{
-					Namespace: boring_namespace,
-					Subsystem: providers_subsystem,
-					Name:      "list_versions",
-					Help:      "Number of boring's providers versions listing.",
+					Namespace: boringNamespace,
+					Subsystem: providersSubsystem,
+					Name:      "list_versions_total",
+					Help:      "The total number of provider versions requests",
 				},
-				[]string{"namespace", "name"},
+				[]string{NamespaceLabel, NameLabel},
 			),
 			Download: promauto.NewCounterVec(
 				prometheus.CounterOpts{
-					Namespace: boring_namespace,
-					Subsystem: providers_subsystem,
-					Name:      "download_version",
-					Help:      "Number of boring's providers download.",
+					Namespace: boringNamespace,
+					Subsystem: providersSubsystem,
+					Name:      "download_version_total",
+					Help:      "The total number of provider download requests",
 				},
-				[]string{"namespace", "name", "version", "os", "arch"},
+				[]string{NamespaceLabel, NameLabel, VersionLabel, OsLabel, ArchLabel},
 			),
 		},
-		Modules: &ModulesMetrics{
+		Module: &ModuleMetrics{
 			ListVersions: promauto.NewCounterVec(
 				prometheus.CounterOpts{
-					Namespace: boring_namespace,
-					Subsystem: modules_subsystem,
-					Name:      "list_versions",
-					Help:      "Number of boring's modules versions listing.",
+					Namespace: boringNamespace,
+					Subsystem: modulesSubsystem,
+					Name:      "list_versions_total",
+					Help:      "The total number of module versions requests",
 				},
-				[]string{"namespace", "name", "provider"},
+				[]string{NamespaceLabel, NameLabel, ProviderLabel},
 			),
 			Download: promauto.NewCounterVec(
 				prometheus.CounterOpts{
-					Namespace: boring_namespace,
-					Subsystem: modules_subsystem,
-					Name:      "download_version",
-					Help:      "Number of boring's modules download.",
+					Namespace: boringNamespace,
+					Subsystem: modulesSubsystem,
+					Name:      "download_version_total",
+					Help:      "The total number of module download requests",
 				},
-				[]string{"namespace", "name", "provider", "version"},
+				[]string{NamespaceLabel, NameLabel, ProviderLabel, VersionLabel},
 			),
 		},
 		Http: &HttpMetrics{
 			RequestsTotal: promauto.NewCounterVec(
 				prometheus.CounterOpts{
-					Namespace: http_namespace,
-					Subsystem: request_subsystem,
+					Namespace: httpNamespace,
+					Subsystem: requestSubsystem,
 					Name:      "total",
-					Help:      "Tracks the number of HTTP requests.",
+					Help:      "The total number of HTTP requests",
 				}, []string{"method", "code"},
 			),
 			RequestDuration: promauto.NewHistogramVec(
 				prometheus.HistogramOpts{
-					Namespace: http_namespace,
-					Subsystem: request_subsystem,
+					Namespace: httpNamespace,
+					Subsystem: requestSubsystem,
 					Name:      "duration_seconds",
-					Help:      "Tracks the latencies for HTTP requests.",
+					Help:      "The HTTP request latencies in seconds",
 					Buckets:   buckets,
 				},
 				[]string{"method", "code"},
 			),
 			RequestSize: promauto.NewSummaryVec(
 				prometheus.SummaryOpts{
-					Namespace: http_namespace,
-					Subsystem: request_subsystem,
+					Namespace: httpNamespace,
+					Subsystem: requestSubsystem,
 					Name:      "size_bytes",
-					Help:      "Tracks the size of HTTP requests.",
+					Help:      "The HTTP request sizes in bytes",
 				},
 				[]string{"method", "code"},
 			),
 			ResponseSize: promauto.NewSummaryVec(
 				prometheus.SummaryOpts{
-					Namespace: http_namespace,
-					Subsystem: response_subsystem,
+					Namespace: httpNamespace,
+					Subsystem: responseSubsystem,
 					Name:      "size_bytes",
-					Help:      "Tracks the size of HTTP responses.",
+					Help:      "The HTTP reponse sizes in bytes",
 				},
 				[]string{"method", "code"},
 			),

--- a/pkg/observability/metrics.go
+++ b/pkg/observability/metrics.go
@@ -1,0 +1,159 @@
+package observability
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type ServerMetrics struct {
+	Mirrors   *MirrorMetrics
+	Modules   *ModulesMetrics
+	Providers *ProvidersMetrics
+	Http      *HttpMetrics
+}
+type MirrorMetrics struct {
+	ListProviderVersions     *prometheus.CounterVec
+	ListProviderInstallation *prometheus.CounterVec
+	RetrieveProviderArchive  *prometheus.CounterVec
+}
+type ModulesMetrics struct {
+	ListVersions *prometheus.CounterVec
+	Download     *prometheus.CounterVec
+}
+type ProvidersMetrics struct {
+	ListVersions *prometheus.CounterVec
+	Download     *prometheus.CounterVec
+}
+type HttpMetrics struct {
+	RequestsTotal   *prometheus.CounterVec
+	RequestDuration *prometheus.HistogramVec
+	RequestSize     *prometheus.SummaryVec
+	ResponseSize    *prometheus.SummaryVec
+}
+
+func NewMetrics(buckets []float64) *ServerMetrics {
+	boring_namespace := "boring_registry"
+	http_namespace := "http"
+
+	mirrors_subsystem := "mirrors"
+	providers_subsystem := "providers"
+	modules_subsystem := "modules"
+	request_subsystem := "request"
+	response_subsystem := "response"
+
+	if buckets == nil {
+		buckets = prometheus.ExponentialBuckets(0.1, 1.5, 5)
+	}
+
+	metrics := &ServerMetrics{
+		Mirrors: &MirrorMetrics{
+			ListProviderVersions: promauto.NewCounterVec(
+				prometheus.CounterOpts{
+					Namespace: boring_namespace,
+					Subsystem: mirrors_subsystem,
+					Name:      "list_provider_versions",
+					Help:      "Number providers versions listing on the mirror.",
+				},
+				[]string{"hostname", "namespace", "name"},
+			),
+			ListProviderInstallation: promauto.NewCounterVec(
+				prometheus.CounterOpts{
+					Namespace: boring_namespace,
+					Subsystem: mirrors_subsystem,
+					Name:      "list_provider_installations",
+					Help:      "Number providers installations listing on the mirror.",
+				},
+				[]string{"hostname", "namespace", "name", "version"},
+			),
+			RetrieveProviderArchive: promauto.NewCounterVec(
+				prometheus.CounterOpts{
+					Namespace: boring_namespace,
+					Subsystem: mirrors_subsystem,
+					Name:      "download_version",
+					Help:      "Number providers retreive and archive on the mirror.",
+				},
+				[]string{"hostname", "namespace", "name", "version", "os", "arch"},
+			),
+		},
+		Providers: &ProvidersMetrics{
+			ListVersions: promauto.NewCounterVec(
+				prometheus.CounterOpts{
+					Namespace: boring_namespace,
+					Subsystem: providers_subsystem,
+					Name:      "list_versions",
+					Help:      "Number of boring's providers versions listing.",
+				},
+				[]string{"namespace", "name"},
+			),
+			Download: promauto.NewCounterVec(
+				prometheus.CounterOpts{
+					Namespace: boring_namespace,
+					Subsystem: providers_subsystem,
+					Name:      "download_version",
+					Help:      "Number of boring's providers download.",
+				},
+				[]string{"namespace", "name", "version", "os", "arch"},
+			),
+		},
+		Modules: &ModulesMetrics{
+			ListVersions: promauto.NewCounterVec(
+				prometheus.CounterOpts{
+					Namespace: boring_namespace,
+					Subsystem: modules_subsystem,
+					Name:      "list_versions",
+					Help:      "Number of boring's modules versions listing.",
+				},
+				[]string{"namespace", "name", "provider"},
+			),
+			Download: promauto.NewCounterVec(
+				prometheus.CounterOpts{
+					Namespace: boring_namespace,
+					Subsystem: modules_subsystem,
+					Name:      "download_version",
+					Help:      "Number of boring's modules download.",
+				},
+				[]string{"namespace", "name", "provider", "version"},
+			),
+		},
+		Http: &HttpMetrics{
+			RequestsTotal: promauto.NewCounterVec(
+				prometheus.CounterOpts{
+					Namespace: http_namespace,
+					Subsystem: request_subsystem,
+					Name:      "total",
+					Help:      "Tracks the number of HTTP requests.",
+				}, []string{"method", "code"},
+			),
+			RequestDuration: promauto.NewHistogramVec(
+				prometheus.HistogramOpts{
+					Namespace: http_namespace,
+					Subsystem: request_subsystem,
+					Name:      "duration_seconds",
+					Help:      "Tracks the latencies for HTTP requests.",
+					Buckets:   buckets,
+				},
+				[]string{"method", "code"},
+			),
+			RequestSize: promauto.NewSummaryVec(
+				prometheus.SummaryOpts{
+					Namespace: http_namespace,
+					Subsystem: request_subsystem,
+					Name:      "size_bytes",
+					Help:      "Tracks the size of HTTP requests.",
+				},
+				[]string{"method", "code"},
+			),
+			ResponseSize: promauto.NewSummaryVec(
+				prometheus.SummaryOpts{
+					Namespace: http_namespace,
+					Subsystem: response_subsystem,
+					Name:      "size_bytes",
+					Help:      "Tracks the size of HTTP responses.",
+				},
+				[]string{"method", "code"},
+			),
+		},
+	}
+
+	return metrics
+}

--- a/pkg/observability/middleware.go
+++ b/pkg/observability/middleware.go
@@ -1,0 +1,44 @@
+package observability
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type Middleware interface {
+	// WrapHandler wraps the given HTTP handler for instrumentation.
+	WrapHandler(handler http.Handler) http.HandlerFunc
+}
+
+type middleware struct {
+	metrics *HttpMetrics
+}
+
+// WrapHandler wraps the given HTTP handler for instrumentation:
+// It reports HTTP metrics to the registered collectors.
+// Each has a constant label named "handler" with the provided handlerName as value.
+func (m *middleware) WrapHandler(handler http.Handler) http.HandlerFunc {
+	wrappedHandler := promhttp.InstrumentHandlerCounter(
+		m.metrics.RequestsTotal,
+		promhttp.InstrumentHandlerDuration(
+			m.metrics.RequestDuration,
+			promhttp.InstrumentHandlerRequestSize(
+				m.metrics.RequestSize,
+				promhttp.InstrumentHandlerResponseSize(
+					m.metrics.ResponseSize,
+					handler,
+				),
+			),
+		),
+	)
+
+	return wrappedHandler.ServeHTTP
+}
+
+// NewMiddleware returns a Middleware interface.
+func NewMiddleware(metrics *HttpMetrics) Middleware {
+	return &middleware{
+		metrics: metrics,
+	}
+}

--- a/pkg/provider/endpoint.go
+++ b/pkg/provider/endpoint.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/boring-registry/boring-registry/pkg/core"
 	o11y "github.com/boring-registry/boring-registry/pkg/observability"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/go-kit/kit/endpoint"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type listRequest struct {
@@ -15,13 +15,13 @@ type listRequest struct {
 	name      string
 }
 
-func listEndpoint(svc Service, metrics *o11y.ProvidersMetrics) endpoint.Endpoint {
+func listEndpoint(svc Service, metrics *o11y.ProviderMetrics) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(listRequest)
 
 		metrics.ListVersions.With(prometheus.Labels{
-			"namespace": req.namespace,
-			"name":      req.name,
+			o11y.NamespaceLabel: req.namespace,
+			o11y.NameLabel:      req.name,
 		}).Inc()
 
 		return svc.ListProviderVersions(ctx, req.namespace, req.name)
@@ -47,16 +47,16 @@ type downloadResponse struct {
 	SigningKeys         core.SigningKeys `json:"signing_keys"`
 }
 
-func downloadEndpoint(svc Service, metrics *o11y.ProvidersMetrics) endpoint.Endpoint {
+func downloadEndpoint(svc Service, metrics *o11y.ProviderMetrics) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(downloadRequest)
 
 		metrics.Download.With(prometheus.Labels{
-			"namespace": req.namespace,
-			"name":      req.name,
-			"version":   req.version,
-			"os":        req.os,
-			"arch":      req.arch,
+			o11y.NamespaceLabel: req.namespace,
+			o11y.NameLabel:      req.name,
+			o11y.VersionLabel:   req.version,
+			o11y.OsLabel:        req.os,
+			o11y.ArchLabel:      req.arch,
 		}).Inc()
 
 		res, err := svc.GetProvider(ctx, req.namespace, req.name, req.version, req.os, req.arch)

--- a/pkg/provider/transport.go
+++ b/pkg/provider/transport.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/boring-registry/boring-registry/pkg/core"
+	o11y "github.com/boring-registry/boring-registry/pkg/observability"
 
 	"github.com/go-kit/kit/auth/jwt"
 	"github.com/go-kit/kit/endpoint"
@@ -25,32 +26,36 @@ const (
 )
 
 // MakeHandler returns a fully initialized http.Handler.
-func MakeHandler(svc Service, auth endpoint.Middleware, options ...httptransport.ServerOption) http.Handler {
+func MakeHandler(svc Service, auth endpoint.Middleware, metrics *o11y.ProvidersMetrics, instrumentation o11y.Middleware, options ...httptransport.ServerOption) http.Handler {
 	r := mux.NewRouter().StrictSlash(true)
 
 	r.Methods("GET").Path(`/{namespace}/{name}/versions`).Handler(
-		httptransport.NewServer(
-			auth(listEndpoint(svc)),
-			decodeListRequest,
-			httptransport.EncodeJSONResponse,
-			append(
-				options,
-				httptransport.ServerBefore(extractMuxVars(varNamespace, varName)),
-				httptransport.ServerBefore(jwt.HTTPToContext()),
-			)...,
+		instrumentation.WrapHandler(
+			httptransport.NewServer(
+				auth(listEndpoint(svc, metrics)),
+				decodeListRequest,
+				httptransport.EncodeJSONResponse,
+				append(
+					options,
+					httptransport.ServerBefore(extractMuxVars(varNamespace, varName)),
+					httptransport.ServerBefore(jwt.HTTPToContext()),
+				)...,
+			),
 		),
 	)
 
 	r.Methods("GET").Path(`/{namespace}/{name}/{version}/download/{os}/{arch}`).Handler(
-		httptransport.NewServer(
-			auth(downloadEndpoint(svc)),
-			decodeDownloadRequest,
-			httptransport.EncodeJSONResponse,
-			append(
-				options,
-				httptransport.ServerBefore(extractMuxVars(varNamespace, varName, varOS, varArch, varVersion)),
-				httptransport.ServerBefore(jwt.HTTPToContext()),
-			)...,
+		instrumentation.WrapHandler(
+			httptransport.NewServer(
+				auth(downloadEndpoint(svc, metrics)),
+				decodeDownloadRequest,
+				httptransport.EncodeJSONResponse,
+				append(
+					options,
+					httptransport.ServerBefore(extractMuxVars(varNamespace, varName, varOS, varArch, varVersion)),
+					httptransport.ServerBefore(jwt.HTTPToContext()),
+				)...,
+			),
 		),
 	)
 

--- a/pkg/provider/transport.go
+++ b/pkg/provider/transport.go
@@ -26,7 +26,7 @@ const (
 )
 
 // MakeHandler returns a fully initialized http.Handler.
-func MakeHandler(svc Service, auth endpoint.Middleware, metrics *o11y.ProvidersMetrics, instrumentation o11y.Middleware, options ...httptransport.ServerOption) http.Handler {
+func MakeHandler(svc Service, auth endpoint.Middleware, metrics *o11y.ProviderMetrics, instrumentation o11y.Middleware, options ...httptransport.ServerOption) http.Handler {
 	r := mux.NewRouter().StrictSlash(true)
 
 	r.Methods("GET").Path(`/{namespace}/{name}/versions`).Handler(

--- a/vendor/github.com/prometheus/client_golang/prometheus/promauto/auto.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/promauto/auto.go
@@ -1,0 +1,376 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package promauto provides alternative constructors for the fundamental
+// Prometheus metric types and their …Vec and …Func variants. The difference to
+// their counterparts in the prometheus package is that the promauto
+// constructors register the Collectors with a registry before returning them.
+// There are two sets of constructors. The constructors in the first set are
+// top-level functions, while the constructors in the other set are methods of
+// the Factory type. The top-level functions return Collectors registered with
+// the global registry (prometheus.DefaultRegisterer), while the methods return
+// Collectors registered with the registry the Factory was constructed with. All
+// constructors panic if the registration fails.
+//
+// The following example is a complete program to create a histogram of normally
+// distributed random numbers from the math/rand package:
+//
+//	package main
+//
+//	import (
+//		"math/rand"
+//		"net/http"
+//
+//		"github.com/prometheus/client_golang/prometheus"
+//		"github.com/prometheus/client_golang/prometheus/promauto"
+//		"github.com/prometheus/client_golang/prometheus/promhttp"
+//	)
+//
+//	var histogram = promauto.NewHistogram(prometheus.HistogramOpts{
+//		Name:    "random_numbers",
+//		Help:    "A histogram of normally distributed random numbers.",
+//		Buckets: prometheus.LinearBuckets(-3, .1, 61),
+//	})
+//
+//	func Random() {
+//		for {
+//			histogram.Observe(rand.NormFloat64())
+//		}
+//	}
+//
+//	func main() {
+//		go Random()
+//		http.Handle("/metrics", promhttp.Handler())
+//		http.ListenAndServe(":1971", nil)
+//	}
+//
+// Prometheus's version of a minimal hello-world program:
+//
+//	package main
+//
+//	import (
+//		"fmt"
+//		"net/http"
+//
+//		"github.com/prometheus/client_golang/prometheus"
+//		"github.com/prometheus/client_golang/prometheus/promauto"
+//		"github.com/prometheus/client_golang/prometheus/promhttp"
+//	)
+//
+//	func main() {
+//		http.Handle("/", promhttp.InstrumentHandlerCounter(
+//			promauto.NewCounterVec(
+//				prometheus.CounterOpts{
+//					Name: "hello_requests_total",
+//					Help: "Total number of hello-world requests by HTTP code.",
+//				},
+//				[]string{"code"},
+//			),
+//			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//				fmt.Fprint(w, "Hello, world!")
+//			}),
+//		))
+//		http.Handle("/metrics", promhttp.Handler())
+//		http.ListenAndServe(":1971", nil)
+//	}
+//
+// A Factory is created with the With(prometheus.Registerer) function, which
+// enables two usage patterns. With(prometheus.Registerer) can be called once per
+// line:
+//
+//	var (
+//		reg           = prometheus.NewRegistry()
+//		randomNumbers = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+//			Name:    "random_numbers",
+//			Help:    "A histogram of normally distributed random numbers.",
+//			Buckets: prometheus.LinearBuckets(-3, .1, 61),
+//		})
+//		requestCount = promauto.With(reg).NewCounterVec(
+//			prometheus.CounterOpts{
+//				Name: "http_requests_total",
+//				Help: "Total number of HTTP requests by status code and method.",
+//			},
+//			[]string{"code", "method"},
+//		)
+//	)
+//
+// Or it can be used to create a Factory once to be used multiple times:
+//
+//	var (
+//		reg           = prometheus.NewRegistry()
+//		factory       = promauto.With(reg)
+//		randomNumbers = factory.NewHistogram(prometheus.HistogramOpts{
+//			Name:    "random_numbers",
+//			Help:    "A histogram of normally distributed random numbers.",
+//			Buckets: prometheus.LinearBuckets(-3, .1, 61),
+//		})
+//		requestCount = factory.NewCounterVec(
+//			prometheus.CounterOpts{
+//				Name: "http_requests_total",
+//				Help: "Total number of HTTP requests by status code and method.",
+//			},
+//			[]string{"code", "method"},
+//		)
+//	)
+//
+// This appears very handy. So why are these constructors locked away in a
+// separate package?
+//
+// The main problem is that registration may fail, e.g. if a metric inconsistent
+// with or equal to the newly to be registered one is already registered.
+// Therefore, the Register method in the prometheus.Registerer interface returns
+// an error, and the same is the case for the top-level prometheus.Register
+// function that registers with the global registry. The prometheus package also
+// provides MustRegister versions for both. They panic if the registration
+// fails, and they clearly call this out by using the Must…  idiom. Panicking is
+// problematic in this case because it doesn't just happen on input provided by
+// the caller that is invalid on its own. Things are a bit more subtle here:
+// Metric creation and registration tend to be spread widely over the
+// codebase. It can easily happen that an incompatible metric is added to an
+// unrelated part of the code, and suddenly code that used to work perfectly
+// fine starts to panic (provided that the registration of the newly added
+// metric happens before the registration of the previously existing
+// metric). This may come as an even bigger surprise with the global registry,
+// where simply importing another package can trigger a panic (if the newly
+// imported package registers metrics in its init function). At least, in the
+// prometheus package, creation of metrics and other collectors is separate from
+// registration. You first create the metric, and then you decide explicitly if
+// you want to register it with a local or the global registry, and if you want
+// to handle the error or risk a panic. With the constructors in the promauto
+// package, registration is automatic, and if it fails, it will always
+// panic. Furthermore, the constructors will often be called in the var section
+// of a file, which means that panicking will happen as a side effect of merely
+// importing a package.
+//
+// A separate package allows conservative users to entirely ignore it. And
+// whoever wants to use it will do so explicitly, with an opportunity to read
+// this warning.
+//
+// Enjoy promauto responsibly!
+package promauto
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// NewCounter works like the function of the same name in the prometheus package
+// but it automatically registers the Counter with the
+// prometheus.DefaultRegisterer. If the registration fails, NewCounter panics.
+func NewCounter(opts prometheus.CounterOpts) prometheus.Counter {
+	return With(prometheus.DefaultRegisterer).NewCounter(opts)
+}
+
+// NewCounterVec works like the function of the same name in the prometheus
+// package but it automatically registers the CounterVec with the
+// prometheus.DefaultRegisterer. If the registration fails, NewCounterVec
+// panics.
+func NewCounterVec(opts prometheus.CounterOpts, labelNames []string) *prometheus.CounterVec {
+	return With(prometheus.DefaultRegisterer).NewCounterVec(opts, labelNames)
+}
+
+// NewCounterFunc works like the function of the same name in the prometheus
+// package but it automatically registers the CounterFunc with the
+// prometheus.DefaultRegisterer. If the registration fails, NewCounterFunc
+// panics.
+func NewCounterFunc(opts prometheus.CounterOpts, function func() float64) prometheus.CounterFunc {
+	return With(prometheus.DefaultRegisterer).NewCounterFunc(opts, function)
+}
+
+// NewGauge works like the function of the same name in the prometheus package
+// but it automatically registers the Gauge with the
+// prometheus.DefaultRegisterer. If the registration fails, NewGauge panics.
+func NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge {
+	return With(prometheus.DefaultRegisterer).NewGauge(opts)
+}
+
+// NewGaugeVec works like the function of the same name in the prometheus
+// package but it automatically registers the GaugeVec with the
+// prometheus.DefaultRegisterer. If the registration fails, NewGaugeVec panics.
+func NewGaugeVec(opts prometheus.GaugeOpts, labelNames []string) *prometheus.GaugeVec {
+	return With(prometheus.DefaultRegisterer).NewGaugeVec(opts, labelNames)
+}
+
+// NewGaugeFunc works like the function of the same name in the prometheus
+// package but it automatically registers the GaugeFunc with the
+// prometheus.DefaultRegisterer. If the registration fails, NewGaugeFunc panics.
+func NewGaugeFunc(opts prometheus.GaugeOpts, function func() float64) prometheus.GaugeFunc {
+	return With(prometheus.DefaultRegisterer).NewGaugeFunc(opts, function)
+}
+
+// NewSummary works like the function of the same name in the prometheus package
+// but it automatically registers the Summary with the
+// prometheus.DefaultRegisterer. If the registration fails, NewSummary panics.
+func NewSummary(opts prometheus.SummaryOpts) prometheus.Summary {
+	return With(prometheus.DefaultRegisterer).NewSummary(opts)
+}
+
+// NewSummaryVec works like the function of the same name in the prometheus
+// package but it automatically registers the SummaryVec with the
+// prometheus.DefaultRegisterer. If the registration fails, NewSummaryVec
+// panics.
+func NewSummaryVec(opts prometheus.SummaryOpts, labelNames []string) *prometheus.SummaryVec {
+	return With(prometheus.DefaultRegisterer).NewSummaryVec(opts, labelNames)
+}
+
+// NewHistogram works like the function of the same name in the prometheus
+// package but it automatically registers the Histogram with the
+// prometheus.DefaultRegisterer. If the registration fails, NewHistogram panics.
+func NewHistogram(opts prometheus.HistogramOpts) prometheus.Histogram {
+	return With(prometheus.DefaultRegisterer).NewHistogram(opts)
+}
+
+// NewHistogramVec works like the function of the same name in the prometheus
+// package but it automatically registers the HistogramVec with the
+// prometheus.DefaultRegisterer. If the registration fails, NewHistogramVec
+// panics.
+func NewHistogramVec(opts prometheus.HistogramOpts, labelNames []string) *prometheus.HistogramVec {
+	return With(prometheus.DefaultRegisterer).NewHistogramVec(opts, labelNames)
+}
+
+// NewUntypedFunc works like the function of the same name in the prometheus
+// package but it automatically registers the UntypedFunc with the
+// prometheus.DefaultRegisterer. If the registration fails, NewUntypedFunc
+// panics.
+func NewUntypedFunc(opts prometheus.UntypedOpts, function func() float64) prometheus.UntypedFunc {
+	return With(prometheus.DefaultRegisterer).NewUntypedFunc(opts, function)
+}
+
+// Factory provides factory methods to create Collectors that are automatically
+// registered with a Registerer. Create a Factory with the With function,
+// providing a Registerer to auto-register created Collectors with. The zero
+// value of a Factory creates Collectors that are not registered with any
+// Registerer. All methods of the Factory panic if the registration fails.
+type Factory struct {
+	r prometheus.Registerer
+}
+
+// With creates a Factory using the provided Registerer for registration of the
+// created Collectors. If the provided Registerer is nil, the returned Factory
+// creates Collectors that are not registered with any Registerer.
+func With(r prometheus.Registerer) Factory { return Factory{r} }
+
+// NewCounter works like the function of the same name in the prometheus package
+// but it automatically registers the Counter with the Factory's Registerer.
+func (f Factory) NewCounter(opts prometheus.CounterOpts) prometheus.Counter {
+	c := prometheus.NewCounter(opts)
+	if f.r != nil {
+		f.r.MustRegister(c)
+	}
+	return c
+}
+
+// NewCounterVec works like the function of the same name in the prometheus
+// package but it automatically registers the CounterVec with the Factory's
+// Registerer.
+func (f Factory) NewCounterVec(opts prometheus.CounterOpts, labelNames []string) *prometheus.CounterVec {
+	c := prometheus.NewCounterVec(opts, labelNames)
+	if f.r != nil {
+		f.r.MustRegister(c)
+	}
+	return c
+}
+
+// NewCounterFunc works like the function of the same name in the prometheus
+// package but it automatically registers the CounterFunc with the Factory's
+// Registerer.
+func (f Factory) NewCounterFunc(opts prometheus.CounterOpts, function func() float64) prometheus.CounterFunc {
+	c := prometheus.NewCounterFunc(opts, function)
+	if f.r != nil {
+		f.r.MustRegister(c)
+	}
+	return c
+}
+
+// NewGauge works like the function of the same name in the prometheus package
+// but it automatically registers the Gauge with the Factory's Registerer.
+func (f Factory) NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge {
+	g := prometheus.NewGauge(opts)
+	if f.r != nil {
+		f.r.MustRegister(g)
+	}
+	return g
+}
+
+// NewGaugeVec works like the function of the same name in the prometheus
+// package but it automatically registers the GaugeVec with the Factory's
+// Registerer.
+func (f Factory) NewGaugeVec(opts prometheus.GaugeOpts, labelNames []string) *prometheus.GaugeVec {
+	g := prometheus.NewGaugeVec(opts, labelNames)
+	if f.r != nil {
+		f.r.MustRegister(g)
+	}
+	return g
+}
+
+// NewGaugeFunc works like the function of the same name in the prometheus
+// package but it automatically registers the GaugeFunc with the Factory's
+// Registerer.
+func (f Factory) NewGaugeFunc(opts prometheus.GaugeOpts, function func() float64) prometheus.GaugeFunc {
+	g := prometheus.NewGaugeFunc(opts, function)
+	if f.r != nil {
+		f.r.MustRegister(g)
+	}
+	return g
+}
+
+// NewSummary works like the function of the same name in the prometheus package
+// but it automatically registers the Summary with the Factory's Registerer.
+func (f Factory) NewSummary(opts prometheus.SummaryOpts) prometheus.Summary {
+	s := prometheus.NewSummary(opts)
+	if f.r != nil {
+		f.r.MustRegister(s)
+	}
+	return s
+}
+
+// NewSummaryVec works like the function of the same name in the prometheus
+// package but it automatically registers the SummaryVec with the Factory's
+// Registerer.
+func (f Factory) NewSummaryVec(opts prometheus.SummaryOpts, labelNames []string) *prometheus.SummaryVec {
+	s := prometheus.NewSummaryVec(opts, labelNames)
+	if f.r != nil {
+		f.r.MustRegister(s)
+	}
+	return s
+}
+
+// NewHistogram works like the function of the same name in the prometheus
+// package but it automatically registers the Histogram with the Factory's
+// Registerer.
+func (f Factory) NewHistogram(opts prometheus.HistogramOpts) prometheus.Histogram {
+	h := prometheus.NewHistogram(opts)
+	if f.r != nil {
+		f.r.MustRegister(h)
+	}
+	return h
+}
+
+// NewHistogramVec works like the function of the same name in the prometheus
+// package but it automatically registers the HistogramVec with the Factory's
+// Registerer.
+func (f Factory) NewHistogramVec(opts prometheus.HistogramOpts, labelNames []string) *prometheus.HistogramVec {
+	h := prometheus.NewHistogramVec(opts, labelNames)
+	if f.r != nil {
+		f.r.MustRegister(h)
+	}
+	return h
+}
+
+// NewUntypedFunc works like the function of the same name in the prometheus
+// package but it automatically registers the UntypedFunc with the Factory's
+// Registerer.
+func (f Factory) NewUntypedFunc(opts prometheus.UntypedOpts, function func() float64) prometheus.UntypedFunc {
+	u := prometheus.NewUntypedFunc(opts, function)
+	if f.r != nil {
+		f.r.MustRegister(u)
+	}
+	return u
+}

--- a/vendor/github.com/prometheus/common/expfmt/decode.go
+++ b/vendor/github.com/prometheus/common/expfmt/decode.go
@@ -45,7 +45,7 @@ func ResponseFormat(h http.Header) Format {
 
 	mediatype, params, err := mime.ParseMediaType(ct)
 	if err != nil {
-		return FmtUnknown
+		return fmtUnknown
 	}
 
 	const textType = "text/plain"
@@ -53,28 +53,28 @@ func ResponseFormat(h http.Header) Format {
 	switch mediatype {
 	case ProtoType:
 		if p, ok := params["proto"]; ok && p != ProtoProtocol {
-			return FmtUnknown
+			return fmtUnknown
 		}
 		if e, ok := params["encoding"]; ok && e != "delimited" {
-			return FmtUnknown
+			return fmtUnknown
 		}
-		return FmtProtoDelim
+		return fmtProtoDelim
 
 	case textType:
 		if v, ok := params["version"]; ok && v != TextVersion {
-			return FmtUnknown
+			return fmtUnknown
 		}
-		return FmtText
+		return fmtText
 	}
 
-	return FmtUnknown
+	return fmtUnknown
 }
 
 // NewDecoder returns a new decoder based on the given input format.
 // If the input format does not imply otherwise, a text format decoder is returned.
 func NewDecoder(r io.Reader, format Format) Decoder {
-	switch format {
-	case FmtProtoDelim:
+	switch format.FormatType() {
+	case TypeProtoDelim:
 		return &protoDecoder{r: r}
 	}
 	return &textDecoder{r: r}

--- a/vendor/github.com/prometheus/common/expfmt/encode.go
+++ b/vendor/github.com/prometheus/common/expfmt/encode.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg"
+	"github.com/prometheus/common/model"
 
 	dto "github.com/prometheus/client_model/go"
 )
@@ -61,23 +62,32 @@ func (ec encoderCloser) Close() error {
 // as the support is still experimental. To include the option to negotiate
 // FmtOpenMetrics, use NegotiateOpenMetrics.
 func Negotiate(h http.Header) Format {
+	escapingScheme := Format(fmt.Sprintf("; escaping=%s", Format(model.NameEscapingScheme.String())))
 	for _, ac := range goautoneg.ParseAccept(h.Get(hdrAccept)) {
+		if escapeParam := ac.Params[model.EscapingKey]; escapeParam != "" {
+			switch Format(escapeParam) {
+			case model.AllowUTF8, model.EscapeUnderscores, model.EscapeDots, model.EscapeValues:
+				escapingScheme = Format(fmt.Sprintf("; escaping=%s", escapeParam))
+			default:
+				// If the escaping parameter is unknown, ignore it.
+			}
+		}
 		ver := ac.Params["version"]
 		if ac.Type+"/"+ac.SubType == ProtoType && ac.Params["proto"] == ProtoProtocol {
 			switch ac.Params["encoding"] {
 			case "delimited":
-				return FmtProtoDelim
+				return fmtProtoDelim + escapingScheme
 			case "text":
-				return FmtProtoText
+				return fmtProtoText + escapingScheme
 			case "compact-text":
-				return FmtProtoCompact
+				return fmtProtoCompact + escapingScheme
 			}
 		}
 		if ac.Type == "text" && ac.SubType == "plain" && (ver == TextVersion || ver == "") {
-			return FmtText
+			return fmtText + escapingScheme
 		}
 	}
-	return FmtText
+	return fmtText + escapingScheme
 }
 
 // NegotiateIncludingOpenMetrics works like Negotiate but includes
@@ -85,29 +95,40 @@ func Negotiate(h http.Header) Format {
 // temporary and will disappear once FmtOpenMetrics is fully supported and as
 // such may be negotiated by the normal Negotiate function.
 func NegotiateIncludingOpenMetrics(h http.Header) Format {
+	escapingScheme := Format(fmt.Sprintf("; escaping=%s", Format(model.NameEscapingScheme.String())))
 	for _, ac := range goautoneg.ParseAccept(h.Get(hdrAccept)) {
+		if escapeParam := ac.Params[model.EscapingKey]; escapeParam != "" {
+			switch Format(escapeParam) {
+			case model.AllowUTF8, model.EscapeUnderscores, model.EscapeDots, model.EscapeValues:
+				escapingScheme = Format(fmt.Sprintf("; escaping=%s", escapeParam))
+			default:
+				// If the escaping parameter is unknown, ignore it.
+			}
+		}
 		ver := ac.Params["version"]
 		if ac.Type+"/"+ac.SubType == ProtoType && ac.Params["proto"] == ProtoProtocol {
 			switch ac.Params["encoding"] {
 			case "delimited":
-				return FmtProtoDelim
+				return fmtProtoDelim + escapingScheme
 			case "text":
-				return FmtProtoText
+				return fmtProtoText + escapingScheme
 			case "compact-text":
-				return FmtProtoCompact
+				return fmtProtoCompact + escapingScheme
 			}
 		}
 		if ac.Type == "text" && ac.SubType == "plain" && (ver == TextVersion || ver == "") {
-			return FmtText
+			return fmtText + escapingScheme
 		}
 		if ac.Type+"/"+ac.SubType == OpenMetricsType && (ver == OpenMetricsVersion_0_0_1 || ver == OpenMetricsVersion_1_0_0 || ver == "") {
-			if ver == OpenMetricsVersion_1_0_0 {
-				return FmtOpenMetrics_1_0_0
+			switch ver {
+			case OpenMetricsVersion_1_0_0:
+				return fmtOpenMetrics_1_0_0 + escapingScheme
+			default:
+				return fmtOpenMetrics_0_0_1 + escapingScheme
 			}
-			return FmtOpenMetrics_0_0_1
 		}
 	}
-	return FmtText
+	return fmtText + escapingScheme
 }
 
 // NewEncoder returns a new encoder based on content type negotiation. All
@@ -116,9 +137,13 @@ func NegotiateIncludingOpenMetrics(h http.Header) Format {
 // for FmtOpenMetrics, but a future (breaking) release will add the Close method
 // to the Encoder interface directly. The current version of the Encoder
 // interface is kept for backwards compatibility.
+// In cases where the Format does not allow for UTF-8 names, the global
+// NameEscapingScheme will be applied.
 func NewEncoder(w io.Writer, format Format) Encoder {
-	switch format {
-	case FmtProtoDelim:
+	escapingScheme := format.ToEscapingScheme()
+
+	switch format.FormatType() {
+	case TypeProtoDelim:
 		return encoderCloser{
 			encode: func(v *dto.MetricFamily) error {
 				_, err := protodelim.MarshalTo(w, v)
@@ -126,34 +151,34 @@ func NewEncoder(w io.Writer, format Format) Encoder {
 			},
 			close: func() error { return nil },
 		}
-	case FmtProtoCompact:
+	case TypeProtoCompact:
 		return encoderCloser{
 			encode: func(v *dto.MetricFamily) error {
-				_, err := fmt.Fprintln(w, v.String())
+				_, err := fmt.Fprintln(w, model.EscapeMetricFamily(v, escapingScheme).String())
 				return err
 			},
 			close: func() error { return nil },
 		}
-	case FmtProtoText:
+	case TypeProtoText:
 		return encoderCloser{
 			encode: func(v *dto.MetricFamily) error {
-				_, err := fmt.Fprintln(w, prototext.Format(v))
+				_, err := fmt.Fprintln(w, prototext.Format(model.EscapeMetricFamily(v, escapingScheme)))
 				return err
 			},
 			close: func() error { return nil },
 		}
-	case FmtText:
+	case TypeTextPlain:
 		return encoderCloser{
 			encode: func(v *dto.MetricFamily) error {
-				_, err := MetricFamilyToText(w, v)
+				_, err := MetricFamilyToText(w, model.EscapeMetricFamily(v, escapingScheme))
 				return err
 			},
 			close: func() error { return nil },
 		}
-	case FmtOpenMetrics_0_0_1, FmtOpenMetrics_1_0_0:
+	case TypeOpenMetrics:
 		return encoderCloser{
 			encode: func(v *dto.MetricFamily) error {
-				_, err := MetricFamilyToOpenMetrics(w, v)
+				_, err := MetricFamilyToOpenMetrics(w, model.EscapeMetricFamily(v, escapingScheme))
 				return err
 			},
 			close: func() error {

--- a/vendor/github.com/prometheus/common/expfmt/expfmt.go
+++ b/vendor/github.com/prometheus/common/expfmt/expfmt.go
@@ -14,30 +14,154 @@
 // Package expfmt contains tools for reading and writing Prometheus metrics.
 package expfmt
 
+import (
+	"strings"
+
+	"github.com/prometheus/common/model"
+)
+
 // Format specifies the HTTP content type of the different wire protocols.
 type Format string
 
-// Constants to assemble the Content-Type values for the different wire protocols.
+// Constants to assemble the Content-Type values for the different wire
+// protocols. The Content-Type strings here are all for the legacy exposition
+// formats, where valid characters for metric names and label names are limited.
+// Support for arbitrary UTF-8 characters in those names is already partially
+// implemented in this module (see model.ValidationScheme), but to actually use
+// it on the wire, new content-type strings will have to be agreed upon and
+// added here.
 const (
 	TextVersion              = "0.0.4"
 	ProtoType                = `application/vnd.google.protobuf`
 	ProtoProtocol            = `io.prometheus.client.MetricFamily`
-	ProtoFmt                 = ProtoType + "; proto=" + ProtoProtocol + ";"
+	protoFmt                 = ProtoType + "; proto=" + ProtoProtocol + ";"
 	OpenMetricsType          = `application/openmetrics-text`
 	OpenMetricsVersion_0_0_1 = "0.0.1"
 	OpenMetricsVersion_1_0_0 = "1.0.0"
 
-	// The Content-Type values for the different wire protocols.
-	FmtUnknown           Format = `<unknown>`
-	FmtText              Format = `text/plain; version=` + TextVersion + `; charset=utf-8`
-	FmtProtoDelim        Format = ProtoFmt + ` encoding=delimited`
-	FmtProtoText         Format = ProtoFmt + ` encoding=text`
-	FmtProtoCompact      Format = ProtoFmt + ` encoding=compact-text`
-	FmtOpenMetrics_1_0_0 Format = OpenMetricsType + `; version=` + OpenMetricsVersion_1_0_0 + `; charset=utf-8`
-	FmtOpenMetrics_0_0_1 Format = OpenMetricsType + `; version=` + OpenMetricsVersion_0_0_1 + `; charset=utf-8`
+	// The Content-Type values for the different wire protocols. Note that these
+	// values are now unexported. If code was relying on comparisons to these
+	// constants, instead use FormatType().
+	fmtUnknown           Format = `<unknown>`
+	fmtText              Format = `text/plain; version=` + TextVersion + `; charset=utf-8`
+	fmtProtoDelim        Format = protoFmt + ` encoding=delimited`
+	fmtProtoText         Format = protoFmt + ` encoding=text`
+	fmtProtoCompact      Format = protoFmt + ` encoding=compact-text`
+	fmtOpenMetrics_1_0_0 Format = OpenMetricsType + `; version=` + OpenMetricsVersion_1_0_0 + `; charset=utf-8`
+	fmtOpenMetrics_0_0_1 Format = OpenMetricsType + `; version=` + OpenMetricsVersion_0_0_1 + `; charset=utf-8`
 )
 
 const (
 	hdrContentType = "Content-Type"
 	hdrAccept      = "Accept"
 )
+
+// FormatType is a Go enum representing the overall category for the given
+// Format. As the number of Format permutations increases, doing basic string
+// comparisons are not feasible, so this enum captures the most useful
+// high-level attribute of the Format string.
+type FormatType int
+
+const (
+	TypeUnknown = iota
+	TypeProtoCompact
+	TypeProtoDelim
+	TypeProtoText
+	TypeTextPlain
+	TypeOpenMetrics
+)
+
+// NewFormat generates a new Format from the type provided. Mostly used for
+// tests, most Formats should be generated as part of content negotiation in
+// encode.go.
+func NewFormat(t FormatType) Format {
+	switch t {
+	case TypeProtoCompact:
+		return fmtProtoCompact
+	case TypeProtoDelim:
+		return fmtProtoDelim
+	case TypeProtoText:
+		return fmtProtoText
+	case TypeTextPlain:
+		return fmtText
+	case TypeOpenMetrics:
+		return fmtOpenMetrics_1_0_0
+	default:
+		return fmtUnknown
+	}
+}
+
+// FormatType deduces an overall FormatType for the given format.
+func (f Format) FormatType() FormatType {
+	toks := strings.Split(string(f), ";")
+	if len(toks) < 2 {
+		return TypeUnknown
+	}
+
+	params := make(map[string]string)
+	for i, t := range toks {
+		if i == 0 {
+			continue
+		}
+		args := strings.Split(t, "=")
+		if len(args) != 2 {
+			continue
+		}
+		params[strings.TrimSpace(args[0])] = strings.TrimSpace(args[1])
+	}
+
+	switch strings.TrimSpace(toks[0]) {
+	case ProtoType:
+		if params["proto"] != ProtoProtocol {
+			return TypeUnknown
+		}
+		switch params["encoding"] {
+		case "delimited":
+			return TypeProtoDelim
+		case "text":
+			return TypeProtoText
+		case "compact-text":
+			return TypeProtoCompact
+		default:
+			return TypeUnknown
+		}
+	case OpenMetricsType:
+		if params["charset"] != "utf-8" {
+			return TypeUnknown
+		}
+		return TypeOpenMetrics
+	case "text/plain":
+		v, ok := params["version"]
+		if !ok {
+			return TypeTextPlain
+		}
+		if v == TextVersion {
+			return TypeTextPlain
+		}
+		return TypeUnknown
+	default:
+		return TypeUnknown
+	}
+}
+
+// ToEscapingScheme returns an EscapingScheme depending on the Format. Iff the
+// Format contains a escaping=allow-utf-8 term, it will select NoEscaping. If a valid
+// "escaping" term exists, that will be used. Otherwise, the global default will
+// be returned.
+func (format Format) ToEscapingScheme() model.EscapingScheme {
+	for _, p := range strings.Split(string(format), ";") {
+		toks := strings.Split(p, "=")
+		if len(toks) != 2 {
+			continue
+		}
+		key, value := strings.TrimSpace(toks[0]), strings.TrimSpace(toks[1])
+		if key == model.EscapingKey {
+			scheme, err := model.ToEscapingScheme(value)
+			if err != nil {
+				return model.NameEscapingScheme
+			}
+			return scheme
+		}
+	}
+	return model.NameEscapingScheme
+}

--- a/vendor/github.com/prometheus/common/expfmt/text_create.go
+++ b/vendor/github.com/prometheus/common/expfmt/text_create.go
@@ -62,6 +62,18 @@ var (
 // contains duplicate metrics or invalid metric or label names, the conversion
 // will result in invalid text format output.
 //
+// If metric names conform to the legacy validation pattern, they will be placed
+// outside the brackets in the traditional way, like `foo{}`. If the metric name
+// fails the legacy validation check, it will be placed quoted inside the
+// brackets: `{"foo"}`. As stated above, the input is assumed to be santized and
+// no error will be thrown in this case.
+//
+// Similar to metric names, if label names conform to the legacy validation
+// pattern, they will be unquoted as normal, like `foo{bar="baz"}`. If the label
+// name fails the legacy validation check, it will be quoted:
+// `foo{"bar"="baz"}`. As stated above, the input is assumed to be santized and
+// no error will be thrown in this case.
+//
 // This method fulfills the type 'prometheus.encoder'.
 func MetricFamilyToText(out io.Writer, in *dto.MetricFamily) (written int, err error) {
 	// Fail-fast checks.
@@ -98,7 +110,7 @@ func MetricFamilyToText(out io.Writer, in *dto.MetricFamily) (written int, err e
 		if err != nil {
 			return
 		}
-		n, err = w.WriteString(name)
+		n, err = writeName(w, name)
 		written += n
 		if err != nil {
 			return
@@ -124,7 +136,7 @@ func MetricFamilyToText(out io.Writer, in *dto.MetricFamily) (written int, err e
 	if err != nil {
 		return
 	}
-	n, err = w.WriteString(name)
+	n, err = writeName(w, name)
 	written += n
 	if err != nil {
 		return
@@ -280,21 +292,9 @@ func writeSample(
 	additionalLabelName string, additionalLabelValue float64,
 	value float64,
 ) (int, error) {
-	var written int
-	n, err := w.WriteString(name)
-	written += n
-	if err != nil {
-		return written, err
-	}
-	if suffix != "" {
-		n, err = w.WriteString(suffix)
-		written += n
-		if err != nil {
-			return written, err
-		}
-	}
-	n, err = writeLabelPairs(
-		w, metric.Label, additionalLabelName, additionalLabelValue,
+	written := 0
+	n, err := writeNameAndLabelPairs(
+		w, name+suffix, metric.Label, additionalLabelName, additionalLabelValue,
 	)
 	written += n
 	if err != nil {
@@ -330,32 +330,64 @@ func writeSample(
 	return written, nil
 }
 
-// writeLabelPairs converts a slice of LabelPair proto messages plus the
-// explicitly given additional label pair into text formatted as required by the
-// text format and writes it to 'w'. An empty slice in combination with an empty
-// string 'additionalLabelName' results in nothing being written. Otherwise, the
-// label pairs are written, escaped as required by the text format, and enclosed
-// in '{...}'. The function returns the number of bytes written and any error
-// encountered.
-func writeLabelPairs(
+// writeNameAndLabelPairs converts a slice of LabelPair proto messages plus the
+// explicitly given metric name and additional label pair into text formatted as
+// required by the text format and writes it to 'w'. An empty slice in
+// combination with an empty string 'additionalLabelName' results in nothing
+// being written. Otherwise, the label pairs are written, escaped as required by
+// the text format, and enclosed in '{...}'. The function returns the number of
+// bytes written and any error encountered. If the metric name is not
+// legacy-valid, it will be put inside the brackets as well. Legacy-invalid
+// label names will also be quoted.
+func writeNameAndLabelPairs(
 	w enhancedWriter,
+	name string,
 	in []*dto.LabelPair,
 	additionalLabelName string, additionalLabelValue float64,
 ) (int, error) {
-	if len(in) == 0 && additionalLabelName == "" {
-		return 0, nil
-	}
 	var (
-		written   int
-		separator byte = '{'
+		written            int
+		separator          byte = '{'
+		metricInsideBraces      = false
 	)
+
+	if name != "" {
+		// If the name does not pass the legacy validity check, we must put the
+		// metric name inside the braces.
+		if !model.IsValidLegacyMetricName(model.LabelValue(name)) {
+			metricInsideBraces = true
+			err := w.WriteByte(separator)
+			written++
+			if err != nil {
+				return written, err
+			}
+			separator = ','
+		}
+		n, err := writeName(w, name)
+		written += n
+		if err != nil {
+			return written, err
+		}
+	}
+
+	if len(in) == 0 && additionalLabelName == "" {
+		if metricInsideBraces {
+			err := w.WriteByte('}')
+			written++
+			if err != nil {
+				return written, err
+			}
+		}
+		return written, nil
+	}
+
 	for _, lp := range in {
 		err := w.WriteByte(separator)
 		written++
 		if err != nil {
 			return written, err
 		}
-		n, err := w.WriteString(lp.GetName())
+		n, err := writeName(w, lp.GetName())
 		written += n
 		if err != nil {
 			return written, err
@@ -460,5 +492,29 @@ func writeInt(w enhancedWriter, i int64) (int, error) {
 	*bp = strconv.AppendInt((*bp)[:0], i, 10)
 	written, err := w.Write(*bp)
 	numBufPool.Put(bp)
+	return written, err
+}
+
+// writeName writes a string as-is if it complies with the legacy naming
+// scheme, or escapes it in double quotes if not.
+func writeName(w enhancedWriter, name string) (int, error) {
+	if model.IsValidLegacyMetricName(model.LabelValue(name)) {
+		return w.WriteString(name)
+	}
+	var written int
+	var err error
+	err = w.WriteByte('"')
+	written++
+	if err != nil {
+		return written, err
+	}
+	var n int
+	n, err = writeEscapedString(w, name, true)
+	written += n
+	if err != nil {
+		return written, err
+	}
+	err = w.WriteByte('"')
+	written++
 	return written, err
 }

--- a/vendor/github.com/prometheus/common/model/metric.go
+++ b/vendor/github.com/prometheus/common/model/metric.go
@@ -18,6 +18,77 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode/utf8"
+
+	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
+)
+
+var (
+	// NameValidationScheme determines the method of name validation to be used by
+	// all calls to IsValidMetricName() and LabelName IsValid(). Setting UTF-8 mode
+	// in isolation from other components that don't support UTF-8 may result in
+	// bugs or other undefined behavior. This value is intended to be set by
+	// UTF-8-aware binaries as part of their startup. To avoid need for locking,
+	// this value should be set once, ideally in an init(), before multiple
+	// goroutines are started.
+	NameValidationScheme = LegacyValidation
+
+	// NameEscapingScheme defines the default way that names will be
+	// escaped when presented to systems that do not support UTF-8 names. If the
+	// Content-Type "escaping" term is specified, that will override this value.
+	NameEscapingScheme = ValueEncodingEscaping
+)
+
+// ValidationScheme is a Go enum for determining how metric and label names will
+// be validated by this library.
+type ValidationScheme int
+
+const (
+	// LegacyValidation is a setting that requirets that metric and label names
+	// conform to the original Prometheus character requirements described by
+	// MetricNameRE and LabelNameRE.
+	LegacyValidation ValidationScheme = iota
+
+	// UTF8Validation only requires that metric and label names be valid UTF-8
+	// strings.
+	UTF8Validation
+)
+
+type EscapingScheme int
+
+const (
+	// NoEscaping indicates that a name will not be escaped. Unescaped names that
+	// do not conform to the legacy validity check will use a new exposition
+	// format syntax that will be officially standardized in future versions.
+	NoEscaping EscapingScheme = iota
+
+	// UnderscoreEscaping replaces all legacy-invalid characters with underscores.
+	UnderscoreEscaping
+
+	// DotsEscaping is similar to UnderscoreEscaping, except that dots are
+	// converted to `_dot_` and pre-existing underscores are converted to `__`.
+	DotsEscaping
+
+	// ValueEncodingEscaping prepends the name with `U__` and replaces all invalid
+	// characters with the unicode value, surrounded by underscores. Single
+	// underscores are replaced with double underscores.
+	ValueEncodingEscaping
+)
+
+const (
+	// EscapingKey is the key in an Accept or Content-Type header that defines how
+	// metric and label names that do not conform to the legacy character
+	// requirements should be escaped when being scraped by a legacy prometheus
+	// system. If a system does not explicitly pass an escaping parameter in the
+	// Accept header, the default NameEscapingScheme will be used.
+	EscapingKey = "escaping"
+
+	// Possible values for Escaping Key:
+	AllowUTF8         = "allow-utf-8" // No escaping required.
+	EscapeUnderscores = "underscores"
+	EscapeDots        = "dots"
+	EscapeValues      = "values"
 )
 
 // MetricNameRE is a regular expression matching valid metric
@@ -84,17 +155,302 @@ func (m Metric) FastFingerprint() Fingerprint {
 	return LabelSet(m).FastFingerprint()
 }
 
-// IsValidMetricName returns true iff name matches the pattern of MetricNameRE.
+// IsValidMetricName returns true iff name matches the pattern of MetricNameRE
+// for legacy names, and iff it's valid UTF-8 if the UTF8Validation scheme is
+// selected.
+func IsValidMetricName(n LabelValue) bool {
+	switch NameValidationScheme {
+	case LegacyValidation:
+		return IsValidLegacyMetricName(n)
+	case UTF8Validation:
+		if len(n) == 0 {
+			return false
+		}
+		return utf8.ValidString(string(n))
+	default:
+		panic(fmt.Sprintf("Invalid name validation scheme requested: %d", NameValidationScheme))
+	}
+}
+
+// IsValidLegacyMetricName is similar to IsValidMetricName but always uses the
+// legacy validation scheme regardless of the value of NameValidationScheme.
 // This function, however, does not use MetricNameRE for the check but a much
 // faster hardcoded implementation.
-func IsValidMetricName(n LabelValue) bool {
+func IsValidLegacyMetricName(n LabelValue) bool {
 	if len(n) == 0 {
 		return false
 	}
 	for i, b := range n {
-		if !((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || b == ':' || (b >= '0' && b <= '9' && i > 0)) {
+		if !isValidLegacyRune(b, i) {
 			return false
 		}
 	}
 	return true
+}
+
+// EscapeMetricFamily escapes the given metric names and labels with the given
+// escaping scheme. Returns a new object that uses the same pointers to fields
+// when possible and creates new escaped versions so as not to mutate the
+// input.
+func EscapeMetricFamily(v *dto.MetricFamily, scheme EscapingScheme) *dto.MetricFamily {
+	if v == nil {
+		return nil
+	}
+
+	if scheme == NoEscaping {
+		return v
+	}
+
+	out := &dto.MetricFamily{
+		Help: v.Help,
+		Type: v.Type,
+	}
+
+	// If the name is nil, copy as-is, don't try to escape.
+	if v.Name == nil || IsValidLegacyMetricName(LabelValue(v.GetName())) {
+		out.Name = v.Name
+	} else {
+		out.Name = proto.String(EscapeName(v.GetName(), scheme))
+	}
+	for _, m := range v.Metric {
+		if !metricNeedsEscaping(m) {
+			out.Metric = append(out.Metric, m)
+			continue
+		}
+
+		escaped := &dto.Metric{
+			Gauge:       m.Gauge,
+			Counter:     m.Counter,
+			Summary:     m.Summary,
+			Untyped:     m.Untyped,
+			Histogram:   m.Histogram,
+			TimestampMs: m.TimestampMs,
+		}
+
+		for _, l := range m.Label {
+			if l.GetName() == MetricNameLabel {
+				if l.Value == nil || IsValidLegacyMetricName(LabelValue(l.GetValue())) {
+					escaped.Label = append(escaped.Label, l)
+					continue
+				}
+				escaped.Label = append(escaped.Label, &dto.LabelPair{
+					Name:  proto.String(MetricNameLabel),
+					Value: proto.String(EscapeName(l.GetValue(), scheme)),
+				})
+				continue
+			}
+			if l.Name == nil || IsValidLegacyMetricName(LabelValue(l.GetName())) {
+				escaped.Label = append(escaped.Label, l)
+				continue
+			}
+			escaped.Label = append(escaped.Label, &dto.LabelPair{
+				Name:  proto.String(EscapeName(l.GetName(), scheme)),
+				Value: l.Value,
+			})
+		}
+		out.Metric = append(out.Metric, escaped)
+	}
+	return out
+}
+
+func metricNeedsEscaping(m *dto.Metric) bool {
+	for _, l := range m.Label {
+		if l.GetName() == MetricNameLabel && !IsValidLegacyMetricName(LabelValue(l.GetValue())) {
+			return true
+		}
+		if !IsValidLegacyMetricName(LabelValue(l.GetName())) {
+			return true
+		}
+	}
+	return false
+}
+
+const (
+	lowerhex = "0123456789abcdef"
+)
+
+// EscapeName escapes the incoming name according to the provided escaping
+// scheme. Depending on the rules of escaping, this may cause no change in the
+// string that is returned. (Especially NoEscaping, which by definition is a
+// noop). This function does not do any validation of the name.
+func EscapeName(name string, scheme EscapingScheme) string {
+	if len(name) == 0 {
+		return name
+	}
+	var escaped strings.Builder
+	switch scheme {
+	case NoEscaping:
+		return name
+	case UnderscoreEscaping:
+		if IsValidLegacyMetricName(LabelValue(name)) {
+			return name
+		}
+		for i, b := range name {
+			if isValidLegacyRune(b, i) {
+				escaped.WriteRune(b)
+			} else {
+				escaped.WriteRune('_')
+			}
+		}
+		return escaped.String()
+	case DotsEscaping:
+		// Do not early return for legacy valid names, we still escape underscores.
+		for i, b := range name {
+			if b == '_' {
+				escaped.WriteString("__")
+			} else if b == '.' {
+				escaped.WriteString("_dot_")
+			} else if isValidLegacyRune(b, i) {
+				escaped.WriteRune(b)
+			} else {
+				escaped.WriteRune('_')
+			}
+		}
+		return escaped.String()
+	case ValueEncodingEscaping:
+		if IsValidLegacyMetricName(LabelValue(name)) {
+			return name
+		}
+		escaped.WriteString("U__")
+		for i, b := range name {
+			if isValidLegacyRune(b, i) {
+				escaped.WriteRune(b)
+			} else if !utf8.ValidRune(b) {
+				escaped.WriteString("_FFFD_")
+			} else if b < 0x100 {
+				escaped.WriteRune('_')
+				for s := 4; s >= 0; s -= 4 {
+					escaped.WriteByte(lowerhex[b>>uint(s)&0xF])
+				}
+				escaped.WriteRune('_')
+			} else if b < 0x10000 {
+				escaped.WriteRune('_')
+				for s := 12; s >= 0; s -= 4 {
+					escaped.WriteByte(lowerhex[b>>uint(s)&0xF])
+				}
+				escaped.WriteRune('_')
+			}
+		}
+		return escaped.String()
+	default:
+		panic(fmt.Sprintf("invalid escaping scheme %d", scheme))
+	}
+}
+
+// lower function taken from strconv.atoi
+func lower(c byte) byte {
+	return c | ('x' - 'X')
+}
+
+// UnescapeName unescapes the incoming name according to the provided escaping
+// scheme if possible. Some schemes are partially or totally non-roundtripable.
+// If any error is enountered, returns the original input.
+func UnescapeName(name string, scheme EscapingScheme) string {
+	if len(name) == 0 {
+		return name
+	}
+	switch scheme {
+	case NoEscaping:
+		return name
+	case UnderscoreEscaping:
+		// It is not possible to unescape from underscore replacement.
+		return name
+	case DotsEscaping:
+		name = strings.ReplaceAll(name, "_dot_", ".")
+		name = strings.ReplaceAll(name, "__", "_")
+		return name
+	case ValueEncodingEscaping:
+		escapedName, found := strings.CutPrefix(name, "U__")
+		if !found {
+			return name
+		}
+
+		var unescaped strings.Builder
+	TOP:
+		for i := 0; i < len(escapedName); i++ {
+			// All non-underscores are treated normally.
+			if escapedName[i] != '_' {
+				unescaped.WriteByte(escapedName[i])
+				continue
+			}
+			i++
+			if i >= len(escapedName) {
+				return name
+			}
+			// A double underscore is a single underscore.
+			if escapedName[i] == '_' {
+				unescaped.WriteByte('_')
+				continue
+			}
+			// We think we are in a UTF-8 code, process it.
+			var utf8Val uint
+			for j := 0; i < len(escapedName); j++ {
+				// This is too many characters for a utf8 value.
+				if j > 4 {
+					return name
+				}
+				// Found a closing underscore, convert to a rune, check validity, and append.
+				if escapedName[i] == '_' {
+					utf8Rune := rune(utf8Val)
+					if !utf8.ValidRune(utf8Rune) {
+						return name
+					}
+					unescaped.WriteRune(utf8Rune)
+					continue TOP
+				}
+				r := lower(escapedName[i])
+				utf8Val *= 16
+				if r >= '0' && r <= '9' {
+					utf8Val += uint(r) - '0'
+				} else if r >= 'a' && r <= 'f' {
+					utf8Val += uint(r) - 'a' + 10
+				} else {
+					return name
+				}
+				i++
+			}
+			// Didn't find closing underscore, invalid.
+			return name
+		}
+		return unescaped.String()
+	default:
+		panic(fmt.Sprintf("invalid escaping scheme %d", scheme))
+	}
+}
+
+func isValidLegacyRune(b rune, i int) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || b == ':' || (b >= '0' && b <= '9' && i > 0)
+}
+
+func (e EscapingScheme) String() string {
+	switch e {
+	case NoEscaping:
+		return AllowUTF8
+	case UnderscoreEscaping:
+		return EscapeUnderscores
+	case DotsEscaping:
+		return EscapeDots
+	case ValueEncodingEscaping:
+		return EscapeValues
+	default:
+		panic(fmt.Sprintf("unknown format scheme %d", e))
+	}
+}
+
+func ToEscapingScheme(s string) (EscapingScheme, error) {
+	if s == "" {
+		return NoEscaping, fmt.Errorf("got empty string instead of escaping scheme")
+	}
+	switch s {
+	case AllowUTF8:
+		return NoEscaping, nil
+	case EscapeUnderscores:
+		return UnderscoreEscaping, nil
+	case EscapeDots:
+		return DotsEscaping, nil
+	case EscapeValues:
+		return ValueEncodingEscaping, nil
+	default:
+		return NoEscaping, fmt.Errorf("unknown format scheme " + s)
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -397,15 +397,16 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/prometheus/client_golang v1.18.0
-## explicit; go 1.19
+# github.com/prometheus/client_golang v1.19.0
+## explicit; go 1.20
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
+github.com/prometheus/client_golang/prometheus/promauto
 github.com/prometheus/client_golang/prometheus/promhttp
 # github.com/prometheus/client_model v0.5.0
 ## explicit; go 1.19
 github.com/prometheus/client_model/go
-# github.com/prometheus/common v0.46.0
+# github.com/prometheus/common v0.48.0
 ## explicit; go 1.20
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg


### PR DESCRIPTION
# What is the topic of this PR

It add custom new metrics to the `/metrics` endpoint.

## Boring's metrics

It adds 3 metrics dédicated to boring : 
|Name|Type|Description|Labels|
|---|---|---|---|
|boring_registry_providers_list_versions|counter|Number of boring's providers versions listing.|namespace, name|
|boring_registry_providers_download_version|counter|Number of boring's providers download.|namespace, name, version, os, arch|
|boring_registry_modules_list_versions|counter|Number of boring's modules versions listing.|namespace, name, provider|
|boring_registry_modules_download_version|counter|Number of boring's modules download.|namespace, name, provider, version|
|boring_registry_mirrors_list_provider_versions|counter|Number providers versions listing on the mirror.|hostname, namespace, name|
|boring_registry_mirrors_list_provider_installations|counter|Number providers retreive and archive on the mirror.|hostname, namespace, name, version|
|boring_registry_mirrors_download_version|counter|Number of boring's modules download.|hostname, namespace, name, version, os, arch|

## "Global" metrics

It add 4 global metrics, dedicated to HTTP traffic: 
|Name|Type|Description|Labels|
|---|---|---|---|
|http_request_total|counter|Tracks the number of HTTP requests.|method, code|
|http_request_duration_seconds|histogram|Tracks the latencies for HTTP requests.|method, code|
|http_request_size_bytes|summary|Tracks the size of HTTP requests.|method, code|
|http_response_size_bytes|summary|Tracks the size of HTTP responses.|method, code|

## Final content rendered

The added content looks like this :
```
# HELP boring_registry_providers_download_version Number of boring's providers download.
# TYPE boring_registry_providers_download_version counter
boring_registry_providers_download_version{arch="amd64",name="the-ring",namespace="lord-of",os="linux",version="0.2.6"} 3
# HELP boring_registry_providers_list_versions Number of boring's providers versions listing.
# TYPE boring_registry_providers_list_versions counter
boring_registry_providers_list_versions{name="the-ring",namespace="lord-of"} 3
# HELP http_request_duration_seconds Tracks the latencies for HTTP requests.
# TYPE http_request_duration_seconds histogram
http_request_duration_seconds_bucket{code="200",method="get",le="0.1"} 2
http_request_duration_seconds_bucket{code="200",method="get",le="0.15000000000000002"} 2
http_request_duration_seconds_bucket{code="200",method="get",le="0.22500000000000003"} 2
http_request_duration_seconds_bucket{code="200",method="get",le="0.3375"} 2
http_request_duration_seconds_bucket{code="200",method="get",le="0.5062500000000001"} 2
http_request_duration_seconds_bucket{code="200",method="get",le="+Inf"} 3
http_request_duration_seconds_sum{code="200",method="get"} 29.646969346000002
http_request_duration_seconds_count{code="200",method="get"} 3
http_request_duration_seconds_bucket{code="500",method="get",le="0.1"} 0
http_request_duration_seconds_bucket{code="500",method="get",le="0.15000000000000002"} 0
http_request_duration_seconds_bucket{code="500",method="get",le="0.22500000000000003"} 0
http_request_duration_seconds_bucket{code="500",method="get",le="0.3375"} 0
http_request_duration_seconds_bucket{code="500",method="get",le="0.5062500000000001"} 0
http_request_duration_seconds_bucket{code="500",method="get",le="+Inf"} 1
http_request_duration_seconds_sum{code="500",method="get"} 30.27717207
http_request_duration_seconds_count{code="500",method="get"} 1
# HELP http_request_size_bytes Tracks the size of HTTP requests.
# TYPE http_request_size_bytes summary
http_request_size_bytes_sum{code="200",method="get"} 2061
http_request_size_bytes_count{code="200",method="get"} 3
http_request_size_bytes_sum{code="500",method="get"} 699
http_request_size_bytes_count{code="500",method="get"} 1
# HELP http_request_total Tracks the number of HTTP requests.
# TYPE http_request_total counter
http_request_total{code="200",method="get"} 3
http_request_total{code="500",method="get"} 1
# HELP http_response_size_bytes Tracks the size of HTTP responses.
# TYPE http_response_size_bytes summary
http_response_size_bytes_sum{code="200",method="get"} 7035
http_response_size_bytes_count{code="200",method="get"} 3
http_response_size_bytes_sum{code="500",method="get"} 3959
http_response_size_bytes_count{code="500",method="get"} 1
```