### PR TITLE
doc: Invalid URL to the Helm documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Support for the [Module Registry Protocol](https://www.terraform.io/internals/mo
 ## Installation
 
 Boring-registry can be installed in various ways, among others we offer a container image and also support the installation with Helm on Kubernetes.
-Learn more about the installation [in our documentation](https://boring-registry.github.io/boring-registry/v0.14.0/installation/helm/).
+Learn more about the installation [in our documentation](https://boring-registry.github.io/boring-registry/latest/installation/helm/).
 
 ## Configuration
 


### PR DESCRIPTION
While reading the doc I found a link pointing to the version 0.14.0 that the documentation website do not contains 😅