### PR TITLE
fix(upload): fix archive file header name when uploading current dir

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -134,7 +134,7 @@ func archiveModule(root string) (io.Reader, error) {
 		}
 
 		// update the name to correctly reflect the desired destination when untaring
-		header.Name = strings.TrimPrefix(strings.Replace(path, root, "", -1), string(filepath.Separator))
+		header.Name = archiveFileHeaderName(path, root)
 
 		if err := tw.WriteHeader(header); err != nil {
 			return err
@@ -175,4 +175,24 @@ func meetsSemverConstraints(spec *module.Spec) (bool, error) {
 // Returns a boolean indicating if the module meets the constraints
 func meetsRegexConstraints(spec *module.Spec) bool {
 	return versionConstraintsRegex.MatchString(spec.Metadata.Version)
+}
+
+func archiveFileHeaderName(path, root string) string {
+	// Check if the module is uploaded non-recursively from the current directory
+	if root == "." {
+		return path
+	}
+
+	// Remove the root prefix from the path
+	if strings.HasPrefix(path, root) {
+		relativePath := strings.TrimPrefix(path, root)
+
+		// the leading slash needs to be removed
+		if strings.HasPrefix(relativePath, "/") {
+			relativePath = relativePath[1:]
+		}
+		return relativePath
+	}
+
+	return path
 }

--- a/cmd/archive_test.go
+++ b/cmd/archive_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArchiveFileHeaderName(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		root   string
+		path   string
+		result string
+	}{
+		{
+			name:   "top-level file in a module",
+			root:   "/tmp/boring-registry/modules/example",
+			path:   "/tmp/boring-registry/modules/example/main.tf",
+			result: "main.tf",
+		},
+		{
+			name:   "nested file in a module",
+			root:   "/tmp/boring-registry/modules/example",
+			path:   "/tmp/boring-registry/modules/example/modules/auth/main.tf",
+			result: "modules/auth/main.tf",
+		},
+		{
+			name:   "hidden file without file extension",
+			root:   "/tmp/boring-registry/modules/example",
+			path:   "/tmp/boring-registry/modules/example/.hidden",
+			result: ".hidden",
+		},
+		{
+			name:   "hidden file without recursive walk",
+			root:   ".",
+			path:   ".hidden",
+			result: ".hidden",
+		},
+		{
+			name:   "file path with parent directory",
+			root:   "../../tmp/boring-registry/modules/example",
+			path:   "../../tmp/boring-registry/modules/example/main.tf",
+			result: "main.tf",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.result, archiveFileHeaderName(tc.path, tc.root))
+		})
+	}
+
+}


### PR DESCRIPTION
This PR fixes #182, which occurs when uploading a module non-recursively with `boring-registry upload <omitted> .`