### PR TITLE
feat: Add possibility to configure volumes

### DIFF
--- a/helm/boring-registry/templates/server-deployment.yaml
+++ b/helm/boring-registry/templates/server-deployment.yaml
@@ -134,6 +134,14 @@ spec:
               port: telemetry
           resources:
             {{- toYaml .Values.server.resources | nindent 12 }}
+          {{- with .Values.server.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.server.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
         {{- if .Values.cachingProxy.enabled }}
         # Sidecar Nginx container
         - name: nginx

--- a/helm/boring-registry/values.yaml
+++ b/helm/boring-registry/values.yaml
@@ -116,6 +116,19 @@ server:
     #   prefix: ""
     #   saEmail: ""
     #   signedURL: false
+  
+  # Additional volumes on the output Deployment definition.
+  volumes: []
+  # - name: foo
+  #   secret:
+  #     secretName: mysecret
+  #     optional: false
+
+  # Additional volumeMounts on the output Deployment definition.
+  volumeMounts: []
+  # - name: foo
+  #   mountPath: "/etc/foo"
+  #   readOnly: true
 
 # the nginx caching proxy configuration
 cachingProxy:


### PR DESCRIPTION
### HELM VOLUME CONFIGURATION

Adding this feature allows us to mount secrets into the pod using CSI driver in k8s.

https://secrets-store-csi-driver.sigs.k8s.io/topics/sync-as-kubernetes-secret 

This is especially needed to provide API keys in an existing secret mounted by an external secrets provider.

