### PR TITLE
[helm] Escape environment variables values

### DIFF
--- a/helm/boring-registry/Chart.yaml
+++ b/helm/boring-registry/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.14.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/boring-registry/templates/server-deployment.yaml
+++ b/helm/boring-registry/templates/server-deployment.yaml
@@ -54,63 +54,63 @@ spec:
             {{- else if .Values.server.auth.existingSecret }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.server.auth.existingSecret }}
-                  key: {{ .Values.server.auth.existingSecretKey }}
+                  name: {{ .Values.server.auth.existingSecret | quote }}
+                  key: {{ .Values.server.auth.existingSecretKey | quote }}
             {{- else }}
-              value: {{ .Values.server.auth.value }}
+              value: {{ .Values.server.auth.value | quote }}
             {{- end }}
 
             {{- if .Values.server.tlsCertFile }}
             - name: BORING_REGISTRY_TLS_CERT_FILE
-              value:  {{ .Values.server.tlsCertFile }}
+              value:  {{ .Values.server.tlsCertFile | quote }}
             {{- end }}
 
             {{- if .Values.server.tlsKeyFile }}
             - name: BORING_REGISTRY_TLS_KEY_FILE
-              value:  {{ .Values.server.tlsKeyFile }}
+              value:  {{ .Values.server.tlsKeyFile | qute }}
             {{- end }}
 
             # Storage configuration.
             {{- with .Values.server.storage.s3 }}
             - name: BORING_REGISTRY_STORAGE_S3_BUCKET
-              value:  {{ .bucket }}
+              value:  {{ .bucket | quote }}
             {{- if .prefix }}
             - name: BORING_REGISTRY_STORAGE_S3_PREFIX
-              value:  {{ .prefix }}
+              value:  {{ .prefix | quote }}
             {{- end }}
             {{- if .region }}
             - name: BORING_REGISTRY_STORAGE_S3_REGION
-              value:  {{ .region }}
+              value:  {{ .region | quote }}
             {{- end }}
             {{- if .endpoint }}
             - name: BORING_REGISTRY_STORAGE_S3_ENDPOINT
-              value:  {{ .endpoint }}
+              value:  {{ .endpoint | quote }}
             {{- end }}
             {{- if .pathStyle }}
             - name: BORING_REGISTRY_STORAGE_S3_PATHSTYLE
-              value:  {{ .pathStyle }}
+              value:  {{ .pathStyle | quote }}
             {{- end }}
             {{- end }}
 
             {{- with .Values.server.storage.gcs }}
             - name: BORING_REGISTRY_STORAGE_GCS_BUCKET
-              value:  {{ .bucket }}
+              value:  {{ .bucket | quote }}
             {{- if .prefix }}
             - name: BORING_REGISTRY_STORAGE_GCS_PREFIX
-              value:  {{ .prefix }}
+              value:  {{ .prefix | quote }}
             {{- end }}
             {{- if .saEmail }}
             - name: BORING_REGISTRY_STORAGE_GCS_SA_EMAIL
-              value:  {{ .saEmail }}
+              value:  {{ .saEmail | quote }}
             {{- end }}
             {{- if .signedURL }}
             - name: BORING_REGISTRY_STORAGE_GCS_SIGNED_URL
-              value:  {{ .signedURL }}
+              value:  {{ .signedURL | quote }}
             {{- end }}
             {{- end }}
 
             {{- range .Values.server.extraEnvs }}
-            - name: {{ .name }}
+            - name: {{ .name | quote }}
             {{- if .value }}
               value: {{ .value | quote }}
             {{- else if .valueFrom }}


### PR DESCRIPTION
Fix a issue where settings `.server.storage.s3.pathStyle` to `"true"` would result in a bool instead of a string, effectively making it impossible to enable s3 with pathStyle