### PR TITLE
(chore) add caching proxy documentation to mkdocs navigation

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -25,6 +25,7 @@ nav:
       - Okta: configuration/authentication/okta.md
     - Download Proxy: configuration/download-proxy.md
     - Provider Network Mirror: configuration/provider-network-mirror.md
+    - Caching Proxy: configuration/caching-proxy.md
   - Tasks:
     - Publish Modules: tasks/publish-modules.md
     - Publish Providers: tasks/publish-providers.md


### PR DESCRIPTION
The documentation was missing in the navigation :facepalm: 

See: https://github.com/boring-registry/boring-registry/actions/runs/12698353071/job/35396655652
```
Run mike deploy v0.15.5 latest --push --update-aliases
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/runner/work/boring-registry/boring-registry/site
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - configuration/caching-proxy.md
```
