### PR TITLE
feat(helm): Enhance default security configuration in helm chart

### DIFF
--- a/helm/boring-registry/templates/cache-config.yaml
+++ b/helm/boring-registry/templates/cache-config.yaml
@@ -9,6 +9,7 @@ data:
   nginx.conf: |
     worker_processes 1;
     events { worker_connections 2048; } # no of connections of clients + proxy upstream
+    pid /tmp/nginx.pid;
 
     http {
       proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=my_cache:10m max_size={{- .Values.cachingProxy.cache.maxSize }} inactive=60m use_temp_path=off;
@@ -21,7 +22,7 @@ data:
       }
 
       server {
-        listen 80;
+        listen 8000;
 
         location / {
           access_log off;

--- a/helm/boring-registry/templates/server-deployment.yaml
+++ b/helm/boring-registry/templates/server-deployment.yaml
@@ -147,7 +147,7 @@ spec:
         - name: nginx
           image: "{{ .Values.cachingProxy.image.repository }}:{{ .Values.cachingProxy.image.tag | default "latest" }}"
           ports:
-            - containerPort: 80
+            - containerPort: 8000
               name: nginx
             - containerPort: 8080
               name: probes
@@ -168,6 +168,10 @@ spec:
               port: probes
           resources:
             {{- toYaml .Values.cachingProxy.resources | nindent 12 }}
+          {{- with .Values.cachingProxy.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: nginx-config
           configMap:

--- a/helm/boring-registry/values.yaml
+++ b/helm/boring-registry/values.yaml
@@ -16,8 +16,22 @@ server:
   replicas: 1
   annotations: {}
   imagePullSecrets: []
-  securityContext: {}
-  podSecurityContext: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    fsGroup: 65534
+    fsGroupChangePolicy: OnRootMismatch
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    privileged: false
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+    capabilities:
+      drop: ["ALL"]
+    seccompProfile:
+      type: RuntimeDefault
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -148,3 +162,13 @@ cachingProxy:
     # limits:
     #   cpu: 100m
     #   memory: 64Mi
+  securityContext:
+    privileged: false
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+    capabilities:
+      drop: ["ALL"]
+    seccompProfile:
+      type: RuntimeDefault


### PR DESCRIPTION
Configures the Pod created in the helm chart to comply with the Restricted Pod Security Standard.

https://kubernetes.io/docs/concepts/security/pod-security-standards/