### PR TITLE
fix(server): check for oidc or okta auth when validating login

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -343,8 +343,10 @@ func authMiddleware(ctx context.Context) (endpoint.Middleware, *discovery.LoginV
 		p, login = setupOkta()
 	}
 
-	if err := login.Validate(); err != nil {
-		return nil, nil, err
+	if login != nil { // Can be nil if neither Oidc or Okta are configured
+		if err := login.Validate(); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	providers = append(providers, p)
@@ -372,7 +374,7 @@ func registerDiscovery(mux *http.ServeMux, login *discovery.LoginV1) error {
 		discovery.WithLoginV1(login),
 	}
 
-	terraformJSON, err := json.Marshal(discovery.New(options...))
+	terraformJSON, err := json.Marshal(discovery.NewDiscovery(options...))
 	if err != nil {
 		return err
 	}

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -86,7 +86,7 @@ func WithLoginV1(login *LoginV1) Option {
 	}
 }
 
-func New(options ...Option) *Discovery {
+func NewDiscovery(options ...Option) *Discovery {
 	discovery := &Discovery{}
 
 	for _, option := range options {


### PR DESCRIPTION
This is a fix for #215 which was accidentally introduced in `v0.16.0` and prevents running the server without configuring OIDC. 