### PR TITLE
Support for Multiple OIDC configurations

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -22,16 +22,19 @@ func Middleware(providers ...Provider) endpoint.Middleware {
 			}
 
 			if token, ok := tokenValue.(string); ok {
+			    var lastError error
 				for _, provider := range providers {
 					err := provider.Verify(ctx, token)
 					if err != nil {
 						slog.Debug("failed to verify token", slog.String("err", err.Error()))
-						return nil, fmt.Errorf("failed to verify token: %w", err)
+						lastError = err
+						continue
 					} else {
 						slog.Debug("successfully verified token")
 						return next(ctx, request)
 					}
 				}
+				return nil, fmt.Errorf("failed to verify token: %w", lastError)
 			} else {
 				return nil, fmt.Errorf("%w: request does not contain a token", core.ErrUnauthorized)
 			}

--- a/pkg/auth/provider_oidc.go
+++ b/pkg/auth/provider_oidc.go
@@ -15,6 +15,14 @@ type OidcProvider struct {
 	provider         *oidc.Provider
 }
 
+type OidcConfig struct {
+    ClientID    string
+    Issuer      string
+    Scopes      []string
+    LoginGrants []string
+    LoginPorts  []int
+}
+
 // Unfortunately, it's difficult to write tests for this method, as we would need an OIDC Authorization Server
 // to generate valid signed JWTs
 func (o *OidcProvider) Verify(ctx context.Context, token string) error {


### PR DESCRIPTION
## Summary: 
This PR introduces support for multiple OIDC providers, refactors the authentication middleware, and improves the handling of OIDC configurations. It also updates the test suite to validate the new functionality.  

## Changes:  
OIDC Configuration: Added support for multiple OIDC providers via the auth-oidc flag, allowing dynamic configuration of client IDs, issuers, scopes, login grants, and ports.
Authentication Middleware: Refactored the middleware to handle multiple providers and return detailed errors for token verification failures.
OIDC Provider Setup: Refactored setupOidc to parse and initialize multiple OIDC configurations.
Discovery Registration: Updated registerDiscovery to handle multiple LoginV1 objects for OIDC providers.
Testing: Enhanced test cases in server_test.go to validate multiple OIDC configurations and ensure proper error handling.

## Testing:  
Verified functionality with single and multiple OIDC providers.
Added unit tests to validate dynamic OIDC configuration parsing and middleware behavior.

## Impact:  
No breaking changes expected.
Requires updating configuration files to use the new auth-oidc flag for multiple OIDC providers.