### PR TITLE
fix(auth): continue token verification if first provider has failed to verify

### DIFF
--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -11,44 +11,70 @@ import (
 func TestAuthMiddleware(t *testing.T) {
 	t.Parallel()
 
-	var (
-		assert = assert.New(t)
-	)
+	type providerCase struct {
+		name      string
+		providers []Provider
+		ctx       context.Context
+		wantError bool
+	}
 
-	testCases := []struct {
-		name        string
-		ctx         context.Context
-		token       string
-		expectError bool
-	}{
+	testCases := []providerCase{
 		{
-			name:        "valid request",
-			ctx:         context.WithValue(context.Background(), jwt.JWTContextKey, "foo"),
-			token:       "foo",
-			expectError: false,
+			name:      "token matches single provider",
+			providers: []Provider{NewStaticProvider("foo")},
+			ctx:       context.WithValue(context.Background(), jwt.JWTContextKey, "foo"),
+			wantError: false,
 		},
 		{
-			name:        "invalid request",
-			ctx:         context.WithValue(context.Background(), jwt.JWTContextKey, "foo"),
-			token:       "bar",
-			expectError: true,
+			name:      "token matches first provider",
+			providers: []Provider{NewStaticProvider("foo"), NewStaticProvider("bar")},
+			ctx:       context.WithValue(context.Background(), jwt.JWTContextKey, "foo"),
+			wantError: false,
+		},
+		{
+			name:      "token matches second provider",
+			providers: []Provider{NewStaticProvider("foo"), NewStaticProvider("bar")},
+			ctx:       context.WithValue(context.Background(), jwt.JWTContextKey, "bar"),
+			wantError: false,
+		},
+		{
+			name:      "token matches none",
+			providers: []Provider{NewStaticProvider("foo"), NewStaticProvider("bar")},
+			ctx:       context.WithValue(context.Background(), jwt.JWTContextKey, "baz"),
+			wantError: true,
+		},
+		{
+			name:      "no token in context",
+			providers: []Provider{NewStaticProvider("foo"), NewStaticProvider("bar")},
+			ctx:       context.Background(),
+			wantError: true,
+		},
+		{
+			name:      "token key is set but empty",
+			providers: []Provider{NewStaticProvider("foo")},
+			ctx:       context.WithValue(context.Background(), jwt.JWTContextKey, ""),
+			wantError: true,
+		},
+		{
+			name:      "no providers, should skip auth",
+			providers: []Provider{},
+			ctx:       context.WithValue(context.Background(), jwt.JWTContextKey, "anything"),
+			wantError: false,
 		},
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := Middleware(NewStaticProvider(tc.token))(nopEndpoint)(tc.ctx, nil)
-			switch tc.expectError {
-			case true:
-				assert.Error(err)
-			case false:
-				assert.NoError(err)
+			_, err := Middleware(tc.providers...)(nopEndpoint)(tc.ctx, nil)
+			if tc.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}
 }
 
-func nopEndpoint(ctx context.Context, request interface{}) (interface{}, error) {
+func nopEndpoint(ctx context.Context, request any) (any, error) {
 	return true, nil
 }

--- a/pkg/auth/provider.go
+++ b/pkg/auth/provider.go
@@ -4,4 +4,7 @@ import "context"
 
 type Provider interface {
 	Verify(ctx context.Context, token string) error
+
+	// String returns the name of the provider implementation
+	String() string
 }

--- a/pkg/auth/provider_oidc.go
+++ b/pkg/auth/provider_oidc.go
@@ -15,6 +15,8 @@ type OidcProvider struct {
 	provider         *oidc.Provider
 }
 
+func (p *OidcProvider) String() string { return "oidc" }
+
 // Unfortunately, it's difficult to write tests for this method, as we would need an OIDC Authorization Server
 // to generate valid signed JWTs
 func (o *OidcProvider) Verify(ctx context.Context, token string) error {


### PR DESCRIPTION
Fixes the bug reported in #228. Previously, the middleware aborted and returned an error on the first error returned by a provider. If multiple providers are configured, it could happen that another provider instance rejected the token and we never actually attempted to verify with the correct provider

Fixes #228