### PR TITLE
chore(renovate): bundle go version upgrades in a single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,14 @@
       "postUpdateOptions": [
         "gomodTidy"
       ]
+    },
+    {
+      "matchPackageNames": [
+        "go",
+        "golang"
+      ],
+      "groupName": "go version",
+      "groupSlug": "go-version"
     }
   ]
 }


### PR DESCRIPTION
This should bundle upgrades to:
* `go.mod` file
* github actions that specify a go version
* go base image in dockerfile