### PR TITLE
chore(goreleaser): remove 32bit architectures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ Chart.lock
 
 # mkdocs
 site
+
+# goreleaser
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,9 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm64
     ldflags:
       - -s
       - -w
@@ -24,7 +27,6 @@ archives:
       {{- .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
Got the following error:
```
  ⨯ build failed after 23s
    error=
    │ build failed: exit status 1: # go.opentelemetry.io/auto/sdk
    │ vendor/go.opentelemetry.io/auto/sdk/tracer.go:88:38: math.MaxUint32 (untyped int constant 4294967295) overflows int
    │ vendor/go.opentelemetry.io/auto/sdk/tracer.go:93:38: math.MaxUint32 (untyped int constant 4294967295) overflows int
    target=windows_arm_6
```