### PR TITLE
feat: add labels to deployment, ingress and serviceAccount

### DIFF
--- a/helm/boring-registry/templates/server-deployment.yaml
+++ b/helm/boring-registry/templates/server-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       labels:
         {{- include "boring-registry.selectorLabels" . | nindent 8 }}
         {{- with .Values.server.labels }}
-        {{- toYaml . | nindent 4 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       {{- with .Values.server.imagePullSecrets }}

--- a/helm/boring-registry/templates/server-deployment.yaml
+++ b/helm/boring-registry/templates/server-deployment.yaml
@@ -17,6 +17,9 @@ spec:
       {{- end }}
       labels:
         {{- include "boring-registry.selectorLabels" . | nindent 8 }}
+        {{- with .Values.server.labels }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
     spec:
       {{- with .Values.server.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/boring-registry/templates/server-ingress.yaml
+++ b/helm/boring-registry/templates/server-ingress.yaml
@@ -18,6 +18,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "boring-registry.labels" . | nindent 4 }}
+  {{- with .Values.server.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.server.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm/boring-registry/templates/server-serviceaccount.yaml
+++ b/helm/boring-registry/templates/server-serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "boring-registry.serviceAccountName" . }}
   labels:
     {{- include "boring-registry.labels" . | nindent 4 }}
+    {{- with .Values.server.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.server.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm/boring-registry/values.yaml
+++ b/helm/boring-registry/values.yaml
@@ -15,6 +15,7 @@ fullnameOverride: ""
 server:
   replicas: 1
   annotations: {}
+  labels: {}
   imagePullSecrets: []
   podSecurityContext:
     runAsNonRoot: true
@@ -52,11 +53,13 @@ server:
   serviceAccount:
     enabled: true
     annotations: {}
+    labels: {}
 
   ingress:
     enabled: false
     className: ""
     annotations: {}
+    labels: {}
     hosts:
       - host: chart-example.local
         paths: []


### PR DESCRIPTION
Summary:

This PR introduces support labels on deployment, ingress and serviceAccount.  
Without configurable labels, boring-registry helm-chart cannot be used with workload identity on AKS at the moment, as the resources needs to be labeled with `azure.workload.identity/use: "true" `

Changes:

Besides the already existing annotations, new properties for labels had been added to server, server.ingress and server.serviceAccount

Testing:

tested against `helm template .` 

Impact: 

no breaking changes expected, as labels are only set additionally and if not empty