### PR TITLE
add multiple oidc support

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -10,6 +10,8 @@ import (
 	"net/http/pprof"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -62,6 +64,7 @@ var (
 	flagAuthStaticTokens []string
 
 	// OIDC auth
+	flagAuthOidc         []string
 	flagAuthOidcIssuer   string
 	flagAuthOidcClientId string
 	flagAuthOidcScopes   []string
@@ -202,6 +205,7 @@ func init() {
 	serverCmd.Flags().StringSliceVar(&flagLoginScopes, "login-scopes", nil, "List of scopes")
 
 	// OIDC auth options
+	serverCmd.Flags().StringSliceVar(&flagAuthOidc, "auth-oidc", []string{}, "Enable multiple OIDC authentication methods. Format: client_id=...;issuer=...;scopes=...;login_grants=...;login_ports=...;accept_non_jwt_tokens=true/false")
 	serverCmd.Flags().StringVar(&flagAuthOidcIssuer, "auth-oidc-issuer", "", "OIDC issuer URL")
 	serverCmd.Flags().StringVar(&flagAuthOidcClientId, "auth-oidc-clientid", "", "OIDC client identifier")
 	serverCmd.Flags().StringSliceVar(&flagAuthOidcScopes, "auth-oidc-scopes", nil, "List of OAuth2 scopes")
@@ -221,7 +225,7 @@ func init() {
 func serveMux(ctx context.Context) (*http.ServeMux, error) {
 	mux := http.NewServeMux()
 
-	authMiddleware, login, err := authMiddleware(ctx)
+	authMiddleware, logins, err := authMiddleware(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +234,7 @@ func serveMux(ctx context.Context) (*http.ServeMux, error) {
 	instrumentation := o11y.NewMiddleware(metrics.Http)
 
 	registerMetrics(mux)
-	if err := registerDiscovery(mux, login); err != nil {
+	if err := registerDiscovery(mux, logins); err != nil {
 		return nil, fmt.Errorf("failed to register discovery: %w", err)
 	}
 
@@ -272,52 +276,218 @@ func serveMux(ctx context.Context) (*http.ServeMux, error) {
 	return mux, nil
 }
 
-func setupOidc(ctx context.Context) (auth.Provider, *discovery.LoginV1, error) {
+func setFieldByKey(config *auth.OidcConfig, key string, value interface{}) error {
+	keyToSetter := map[string]func(*auth.OidcConfig, interface{}) error{
+		"client_id": func(c *auth.OidcConfig, v interface{}) error {
+			str, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("invalid type for client_id: expected string")
+			}
+			c.ClientID = str
+			return nil
+		},
+		"issuer": func(c *auth.OidcConfig, v interface{}) error {
+			str, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("invalid type for issuer: expected string")
+			}
+			c.Issuer = str
+			return nil
+		},
+		"scopes": func(c *auth.OidcConfig, v interface{}) error {
+			scopes, ok := v.([]string)
+			if !ok {
+				return fmt.Errorf("invalid type for scopes: expected []string")
+			}
+			c.Scopes = scopes
+			return nil
+		},
+		"login_grants": func(c *auth.OidcConfig, v interface{}) error {
+			grants, ok := v.([]string)
+			if !ok {
+				return fmt.Errorf("invalid type for login_grants: expected []string")
+			}
+			c.LoginGrants = grants
+			return nil
+		},
+		"login_ports": func(c *auth.OidcConfig, v interface{}) error {
+			ports, ok := v.([]int)
+			if !ok {
+				return fmt.Errorf("invalid type for login_ports: expected []int")
+			}
+			c.LoginPorts = ports
+			return nil
+		},
+	}
+
+	setter, ok := keyToSetter[key]
+	if !ok {
+		return fmt.Errorf("no mapping found for key: %s", key)
+	}
+
+	return setter(config, value)
+}
+
+func parseOidc(ctx context.Context) ([]auth.OidcConfig, error) {
+	parsedList := []auth.OidcConfig{}
+
+	if len(flagAuthOidc) != 0 {
+		slog.Debug("flagAuthOidc", "value", flagAuthOidc)
+		for _, oidcConfig := range flagAuthOidc {
+			parsed := &auth.OidcConfig{
+				ClientID:    "",
+				Issuer:      "",
+				Scopes:      []string{},
+				LoginGrants: flagLoginGrantTypes,
+				LoginPorts:  flagLoginPorts,
+			}
+
+			pairs := strings.Split(oidcConfig, ";")
+
+			for _, pair := range pairs {
+				if pair == "" {
+					continue
+				}
+				kv := strings.SplitN(pair, "=", 2)
+				if len(kv) != 2 {
+					return nil, fmt.Errorf("invalid key-value pair: %s", pair)
+				}
+				key := strings.TrimSpace(kv[0])
+				value := strings.TrimSpace(kv[1])
+
+				if key == "scopes" || key == "login_grants" {
+					err := setFieldByKey(parsed, key, strings.Split(value, ","))
+					if err != nil {
+						return nil, fmt.Errorf("invalid OIDC configuration %s: %w", key, err)
+					}
+				} else if key == "login_ports" {
+					ports := strings.Split(value, ",")
+					intPorts := []int{}
+					for _, port := range ports {
+						intPort, err := strconv.Atoi(strings.TrimSpace(port))
+						if err != nil {
+							return nil, fmt.Errorf("invalid port value: %s", port)
+						}
+						intPorts = append(intPorts, intPort)
+					}
+					err := setFieldByKey(parsed, key, intPorts)
+					if err != nil {
+						return nil, fmt.Errorf("invalid OIDC configuration %s: %w", key, err)
+					}
+				} else if key == "accept_non_jwt_tokens" {
+					boolValue, err := strconv.ParseBool(value)
+					if err != nil {
+						return nil, fmt.Errorf("invalid boolean value for accept_non_jwt_tokens: %s", value)
+					}
+					err = setFieldByKey(parsed, key, boolValue)
+					if err != nil {
+						return nil, fmt.Errorf("invalid OIDC configuration %s: %w", key, err)
+					}
+				} else {
+					err := setFieldByKey(parsed, key, value)
+					if err != nil {
+						return nil, fmt.Errorf("invalid OIDC configuration %s: %w", key, err)
+					}
+				}
+			}
+			parsedList = append(parsedList, *parsed)
+		}
+	} else {
+		slog.Debug("setting up oidc auth",
+			slog.String("client-id", flagAuthOidcClientId),
+			slog.String("issuer", flagAuthOidcIssuer),
+			slog.Any("login-grant", flagLoginGrantTypes),
+			slog.Any("login-ports", flagLoginPorts),
+			slog.Any("scopes", flagAuthOidcScopes),
+		)
+
+		parsed := &auth.OidcConfig{
+			ClientID:    flagAuthOidcClientId,
+			Issuer:      flagAuthOidcIssuer,
+			Scopes:      flagAuthOidcScopes,
+			LoginGrants: flagLoginGrantTypes,
+			LoginPorts:  flagLoginPorts,
+		}
+		parsedList = append(parsedList, *parsed)
+	}
+
+	return parsedList, nil
+}
+
+func setupOidc(ctx context.Context) ([]auth.Provider, []*discovery.LoginV1, error) {
 	authCtx, cancelAuthCtx := context.WithTimeout(ctx, 15*time.Second)
 	defer cancelAuthCtx()
 
-	slog.Debug("setting up oidc auth",
-		slog.String("client-id", flagAuthOidcClientId),
-		slog.String("issuer", flagAuthOidcIssuer),
-		slog.String("client-id", flagAuthOidcClientId),
-		slog.Any("ports", flagLoginPorts),
-		slog.Any("scopes", flagAuthOidcScopes),
-	)
-
-	provider, err := auth.NewOidcProvider(authCtx, flagAuthOidcIssuer, flagAuthOidcClientId)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to set up oidc provider: %w", err)
+	oidcConfigs, error := parseOidc(ctx)
+	if error != nil {
+		return nil, nil, fmt.Errorf("failed to parse OIDC configuration: %w", error)
 	}
 
-	login := &discovery.LoginV1{
-		Client:     flagAuthOidcClientId,
-		GrantTypes: flagLoginGrantTypes,
-		Authz:      provider.AuthURL(),
-		Token:      provider.TokenURL(),
-		Ports:      flagLoginPorts,
-		Scopes:     flagAuthOidcScopes,
+	providers := []auth.Provider{}
+	logins := []*discovery.LoginV1{}
+
+	// Check if global login flags are provided
+	hasGlobalLoginFlags := flagAuthOktaAuthz != "" && flagAuthOktaToken != "" && flagAuthOktaClientId != ""
+
+	for i, config := range oidcConfigs {
+		slog.Debug("setting up oidc auth", slog.Any("config", config))
+		provider, err := auth.NewOidcProvider(authCtx, config.Issuer, config.ClientID, config.AcceptNonJWTTokens)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to set up oidc provider: %w", err)
+		}
+
+		// Only create login configuration for the first provider if global login flags are provided
+		// or if this is the first provider and no global flags are provided
+		if (hasGlobalLoginFlags && i == 0) || (!hasGlobalLoginFlags && i == 0) {
+			var login *discovery.LoginV1
+			if hasGlobalLoginFlags {
+				// Use global login flags
+				login = &discovery.LoginV1{
+					Client:     flagAuthOktaClientId,
+					GrantTypes: flagLoginGrantTypes,
+					Authz:      flagAuthOktaAuthz,
+					Token:      flagAuthOktaToken,
+					Ports:      flagLoginPorts,
+					Scopes:     flagLoginScopes,
+				}
+			} else {
+				// Use provider-specific login configuration
+				login = &discovery.LoginV1{
+					Client:     config.ClientID,
+					GrantTypes: config.LoginGrants,
+					Authz:      provider.AuthURL(),
+					Token:      provider.TokenURL(),
+					Ports:      config.LoginPorts,
+					Scopes:     config.Scopes,
+				}
+			}
+			logins = append(logins, login)
+		}
+
+		providers = append(providers, provider)
 	}
 
-	return provider, login, nil
+	return providers, logins, nil
 }
 
-func setupOkta() (auth.Provider, *discovery.LoginV1) {
+func setupOkta() ([]auth.Provider, []*discovery.LoginV1) {
 	slog.Debug("setting up okta auth", slog.String("issuer", flagAuthOktaIssuer), slog.String("client-id", flagAuthOktaClientId))
 	slog.Warn("Okta auth is deprecated, please migrate to OIDC auth")
-	p := auth.NewOktaProvider(flagAuthOktaIssuer, flagAuthOktaClaims...)
-	login := &discovery.LoginV1{
+	p := []auth.Provider{auth.NewOktaProvider(flagAuthOktaIssuer, flagAuthOktaClaims...)}
+	login := []*discovery.LoginV1{&discovery.LoginV1{
 		Client:     flagAuthOktaClientId,
 		GrantTypes: flagLoginGrantTypes,
 		Authz:      flagAuthOktaAuthz,
 		Token:      flagAuthOktaToken,
 		Ports:      flagLoginPorts,
 		Scopes:     flagLoginScopes,
+	},
 	}
 
 	return p, login
 }
 
-func authMiddleware(ctx context.Context) (endpoint.Middleware, *discovery.LoginV1, error) {
+func authMiddleware(ctx context.Context) (endpoint.Middleware, []*discovery.LoginV1, error) {
 	providers := []auth.Provider{}
 
 	if flagAuthStaticTokens != nil {
@@ -326,34 +496,35 @@ func authMiddleware(ctx context.Context) (endpoint.Middleware, *discovery.LoginV
 
 	// Check if OIDC or Okta are configured, we only want to allow one at a time.
 	// OIDC is recommended, we want to deprecate our Okta-specific implementation and use our OIDC implementation instead, which Okta also supports.
-	if flagAuthOidcIssuer != "" && flagAuthOktaIssuer != "" {
+	if (flagAuthOidcIssuer != "" || len(flagAuthOidc) > 0) && flagAuthOktaIssuer != "" {
 		return nil, nil, errors.New("both OIDC and Okta are configured, only one is allowed at a time")
 	}
 
 	// We construct the discovery.LoginV1 on this level, as we need the OIDC provider to look up the
 	// authorization and token endpoints dynamically to populate the LoginV1
-	var login *discovery.LoginV1
-	if flagAuthOidcIssuer != "" || flagAuthOktaIssuer != "" {
-		var p auth.Provider
-		if flagAuthOidcIssuer != "" {
+	var logins []*discovery.LoginV1
+	if flagAuthOidcIssuer != "" || len(flagAuthOidc) > 0 || flagAuthOktaIssuer != "" {
+		var ps []auth.Provider
+		if flagAuthOidcIssuer != "" || len(flagAuthOidc) > 0 {
 			var err error
-			p, login, err = setupOidc(ctx)
+			ps, logins, err = setupOidc(ctx)
 			if err != nil {
 				return nil, nil, err
 			}
 		} else if flagAuthOktaIssuer != "" {
-			p, login = setupOkta()
+			ps, logins = setupOkta()
 		}
-		providers = append(providers, p)
+		providers = append(providers, ps...)
 	}
 
-	if login != nil { // Can be nil if neither Oidc, Okta, or API token are configured
-		if err := login.Validate(); err != nil {
+	// Only validate the first login configuration, as the discovery mechanism only supports one
+	if len(logins) > 0 && logins[0] != nil {
+		if err := logins[0].Validate(); err != nil {
 			return nil, nil, err
 		}
 	}
 
-	return auth.Middleware(providers...), login, nil
+	return auth.Middleware(providers...), logins, nil
 }
 
 func registerMetrics(mux *http.ServeMux) {
@@ -370,11 +541,14 @@ func registerMetrics(mux *http.ServeMux) {
 	mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
 }
 
-func registerDiscovery(mux *http.ServeMux, login *discovery.LoginV1) error {
+func registerDiscovery(mux *http.ServeMux, logins []*discovery.LoginV1) error {
 	options := []discovery.Option{
 		discovery.WithModulesV1(fmt.Sprintf("%s/", prefixModules)),
 		discovery.WithProvidersV1(fmt.Sprintf("%s/", prefixProviders)),
-		discovery.WithLoginV1(login),
+	}
+
+	for _, login := range logins {
+		options = append(options, discovery.WithLoginV1(login))
 	}
 
 	terraformJSON, err := json.Marshal(discovery.NewDiscovery(options...))

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -2,14 +2,25 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/boring-registry/boring-registry/pkg/discovery"
 	"github.com/stretchr/testify/assert"
 )
+
+func findLoginByClient(logins []*discovery.LoginV1, clientID []string) bool {
+	for index, login := range logins {
+		if login.Client != clientID[index] {
+			return false
+		}
+	}
+	return true
+}
 
 func TestAuthMiddleware(t *testing.T) {
 	data := `{
@@ -32,15 +43,18 @@ func TestAuthMiddleware(t *testing.T) {
 	defer s.Close()
 
 	tests := []struct {
-		name             string
-		authOidcIssuer   string
-		authOidcClientId string
-		authOktaIssuer   string
-		authOktaClientId string
-		authOktaAuthz    string
-		authOktaToken    string
-		wantErr          bool
-		errMessage       string
+		name                string
+		authOidc            []string
+		authOidcIssuer      string
+		authOidcClientId    string
+		authOktaIssuer      string
+		authOktaClientId    string
+		authOktaAuthz       string
+		authOktaToken       string
+		wantErr             bool
+		errMessage          string
+		authIssuer          string
+		expectedOidcClients []string
 	}{
 		{
 			name:             "only OIDC is configured",
@@ -62,33 +76,53 @@ func TestAuthMiddleware(t *testing.T) {
 			authOktaAuthz:    "/authz",
 			authOktaToken:    "/token",
 		},
+		{
+			name: "Multiple OIDC set",
+			authOidc: []string{
+				fmt.Sprintf("client_id=boring-registry-test1;issuer=%s;scopes=openid;login_grants=grants1,grants2;login_ports=123,456", s.URL),
+				fmt.Sprintf("client_id=boring-registry-test2;issuer=%s;scopes=openid", s.URL),
+			},
+			authIssuer:          s.URL,
+			expectedOidcClients: []string{"boring-registry-test1", "boring-registry-test2"},
+		},
 	}
 
 	for _, test := range tests {
 		// Initializing global variables, this is potentially problematic!
 		flagAuthOidcIssuer = test.authOidcIssuer
+		if flagAuthOidcIssuer == "" {
+			flagAuthOidcIssuer = test.authIssuer
+		}
 		flagAuthOidcClientId = test.authOidcClientId
 		flagAuthOktaIssuer = test.authOktaIssuer
 		flagAuthOktaClientId = test.authOktaClientId
 		flagAuthOktaAuthz = test.authOktaAuthz
 		flagAuthOktaToken = test.authOktaToken
+		flagAuthOidc = test.authOidc
 
-		mw, login, err := authMiddleware(context.Background())
+		mw, logins, err := authMiddleware(context.Background())
 		if test.wantErr {
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, test.errMessage)
 		} else {
 			assert.NoError(t, err)
-			if assert.NotNil(t, login) {
-				if test.authOidcIssuer != "" {
-					assert.Equal(t, test.authOidcClientId, login.Client)
+			if assert.NotNil(t, logins) {
+				if len(test.authOidc) > 0 {
+					assert.True(t, findLoginByClient(logins, test.expectedOidcClients), "Expected clients not found in logins")
+				} else if test.authOidcIssuer != "" {
+					assert.True(t, findLoginByClient(logins, []string{test.authOidcClientId}), "Expected client not found in logins")
 				} else if test.authOktaIssuer != "" {
-					assert.Equal(t, test.authOktaClientId, login.Client)
+					assert.True(t, findLoginByClient(logins, []string{test.authOktaClientId}), "Expected client not found in logins")
 				}
-				assert.NotEmpty(t, login.Authz)
-				assert.NotEmpty(t, login.Token)
-				assert.NotEmpty(t, login.GrantTypes)
-				assert.NotEmpty(t, login.Ports)
+
+				for _, login := range logins {
+					if test.authOidcIssuer != "" || test.authOktaIssuer != "" {
+						assert.NotEmpty(t, login.Authz)
+						assert.NotEmpty(t, login.Token)
+						assert.NotEmpty(t, login.GrantTypes)
+						assert.NotEmpty(t, login.Ports)
+					}
+				}
 			}
 			assert.NotNil(t, mw)
 		}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -2,8 +2,11 @@ package auth
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/boring-registry/boring-registry/pkg/core"
 
@@ -11,12 +14,55 @@ import (
 	"github.com/go-kit/kit/endpoint"
 )
 
+type TokenClaims struct {
+	Issuer string `json:"iss"`
+}
+
+func parseJWTIssuer(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("malformed jwt, expected 3 parts got %d", len(parts))
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("malformed jwt payload: %v", err)
+	}
+
+	var claims TokenClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("failed to unmarshal claims: %v", err)
+	}
+
+	return claims.Issuer, nil
+}
+
+type IssuerProvider interface {
+	Provider
+	GetIssuer() string
+}
+
+func findMatchingProvider(providers []Provider, issuer string) Provider {
+	for _, provider := range providers {
+		if issuerProvider, ok := provider.(IssuerProvider); ok {
+			if issuerProvider.GetIssuer() == issuer {
+				return provider
+			}
+		}
+	}
+	return nil
+}
+
+func isLikelyJWT(token string) bool {
+	parts := strings.Split(token, ".")
+	return len(parts) == 3
+}
+
 func Middleware(providers ...Provider) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request any) (any, error) {
 			tokenValue := ctx.Value(jwt.JWTContextKey)
 
-			// Skip any authorization checks, as there are no providers defined
 			if len(providers) == 0 {
 				return next(ctx, request)
 			}
@@ -26,16 +72,42 @@ func Middleware(providers ...Provider) endpoint.Middleware {
 				return nil, fmt.Errorf("%w: request does not contain a token", core.ErrUnauthorized)
 			}
 
-			// Iterate through all providers and attempt to verify the token
-			for _, provider := range providers {
-				err := provider.Verify(ctx, token)
+			if isLikelyJWT(token) {
+				issuer, err := parseJWTIssuer(token)
 				if err != nil {
-					slog.Debug("failed to verify token", slog.String("provider", provider.String()), slog.String("err", err.Error()))
-					continue
+					slog.Debug("failed to parse JWT issuer", slog.String("err", err.Error()))
 				} else {
-					slog.Debug("successfully verified token", slog.String("provider", provider.String()))
-					return next(ctx, request)
+					matchingProvider := findMatchingProvider(providers, issuer)
+					if matchingProvider != nil {
+						slog.Debug("found matching provider for issuer", slog.String("issuer", issuer))
+						err := matchingProvider.Verify(ctx, token)
+						if err != nil {
+							slog.Debug("failed to verify token with matching provider", slog.String("issuer", issuer), slog.String("err", err.Error()))
+							return nil, fmt.Errorf("failed to verify token: %w", err)
+						} else {
+							slog.Debug("successfully verified token with matching provider", slog.String("issuer", issuer))
+							return next(ctx, request)
+						}
+					}
 				}
+
+				var lastError error
+
+				// Iterate through all providers and attempt to verify the token
+				for _, provider := range providers {
+					err := provider.Verify(ctx, token)
+					if err != nil {
+						slog.Debug("failed to verify token", slog.String("provider", provider.String()), slog.String("err", err.Error()))
+						lastError = err
+						continue
+					} else {
+						slog.Debug("successfully verified token", slog.String("provider", provider.String()))
+						return next(ctx, request)
+					}
+				}
+				return nil, fmt.Errorf("failed to verify token: %w", lastError)
+			} else {
+				return nil, fmt.Errorf("%w: request does not contain a token", core.ErrUnauthorized)
 			}
 
 			// No provider could verify the token

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -2,13 +2,339 @@ package auth
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
 	"testing"
 
 	"github.com/go-kit/kit/auth/jwt"
 	"github.com/stretchr/testify/assert"
 )
 
+type mockProvider struct {
+	name          string
+	issuer        string
+	shouldSucceed bool
+	verifyFunc    func(ctx context.Context, token string) error
+}
+
+func (m *mockProvider) Verify(ctx context.Context, token string) error {
+	if m.verifyFunc != nil {
+		return m.verifyFunc(ctx, token)
+	}
+	if m.shouldSucceed {
+		return nil
+	}
+	return fmt.Errorf("mock verification failed for %s", m.name)
+}
+
+func (m *mockProvider) GetIssuer() string {
+	return m.issuer
+}
+
+type mockOidcProvider struct {
+	*mockProvider
+}
+
+func (m *mockOidcProvider) GetIssuer() string {
+	return m.issuer
+}
+
+func createJWTWithIssuer(issuer string) string {
+	header := `{"alg":"HS256","typ":"JWT"}`
+	payload := fmt.Sprintf(`{"iss":"%s","sub":"1234567890","name":"John Doe","iat":1516239022}`, issuer)
+
+	headerB64 := base64.RawURLEncoding.EncodeToString([]byte(header))
+	payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	signature := base64.RawURLEncoding.EncodeToString([]byte("dummy-signature"))
+
+	return fmt.Sprintf("%s.%s.%s", headerB64, payloadB64, signature)
+}
+
+func TestParseJWTIssuer(t *testing.T) {
+	tests := []struct {
+		name        string
+		token       string
+		expectedIss string
+		expectError bool
+	}{
+		{
+			name:        "valid JWT",
+			token:       createJWTWithIssuer("https://example.com"),
+			expectedIss: "https://example.com",
+			expectError: false,
+		},
+		{
+			name:        "malformed JWT only 2 parts",
+			token:       "header.payload",
+			expectedIss: "",
+			expectError: true,
+		},
+		{
+			name:        "malformed JWT 4 parts",
+			token:       "header.payload.signature.extra",
+			expectedIss: "",
+			expectError: true,
+		},
+		{
+			name:        "invalid base64 payload",
+			token:       "header.@invalid@base64@.signature",
+			expectedIss: "",
+			expectError: true,
+		},
+		{
+			name:        "invalid JSON payload",
+			token:       fmt.Sprintf("header.%s.signature", base64.RawURLEncoding.EncodeToString([]byte("invalid json"))),
+			expectedIss: "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issuer, err := parseJWTIssuer(tt.token)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedIss, issuer)
+			}
+		})
+	}
+}
+
+func TestFindMatchingProvider(t *testing.T) {
+	oidcProvider1 := &mockOidcProvider{
+		mockProvider: &mockProvider{
+			name:   "provider1",
+			issuer: "https://example1.com",
+		},
+	}
+	oidcProvider2 := &mockOidcProvider{
+		mockProvider: &mockProvider{
+			name:   "provider2",
+			issuer: "https://example2.com",
+		},
+	}
+	staticProvider := &mockProvider{name: "static"}
+
+	providers := []Provider{oidcProvider1, oidcProvider2, staticProvider}
+
+	tests := []struct {
+		name     string
+		issuer   string
+		expected Provider
+	}{
+		{
+			name:     "find matching provider",
+			issuer:   "https://example1.com",
+			expected: oidcProvider1,
+		},
+		{
+			name:     "find second matching provider",
+			issuer:   "https://example2.com",
+			expected: oidcProvider2,
+		},
+		{
+			name:     "no matching provider",
+			issuer:   "https://unknown.com",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := findMatchingProvider(providers, tt.issuer)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsLikelyJWT(t *testing.T) {
+	tests := []struct {
+		name     string
+		token    string
+		expected bool
+	}{
+		{
+			name:     "valid JWT format",
+			token:    "header.payload.signature",
+			expected: true,
+		},
+		{
+			name:     "invalid JWT format 2 parts",
+			token:    "header.payload",
+			expected: false,
+		},
+		{
+			name:     "invalid JWT format 4 parts",
+			token:    "header.payload.signature.extra",
+			expected: false,
+		},
+		{
+			name:     "single token",
+			token:    "simpletoken",
+			expected: false,
+		},
+		{
+			name:     "empty token",
+			token:    "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isLikelyJWT(tt.token)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestAuthMiddleware(t *testing.T) {
+	t.Parallel()
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelError})))
+
+	t.Run("no providers should skip auth", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), jwt.JWTContextKey, "any-token")
+		_, err := Middleware()(nopEndpoint)(ctx, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("no token in context", func(t *testing.T) {
+		provider := &mockProvider{name: "test", shouldSucceed: true}
+		ctx := context.Background()
+		_, err := Middleware(provider)(nopEndpoint)(ctx, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unauthorized")
+	})
+
+	t.Run("non-JWT token with supporting provider", func(t *testing.T) {
+		nonJWTProvider := &mockProvider{
+			name: "nonJWTProvider",
+			verifyFunc: func(ctx context.Context, token string) error {
+				if token == "ci-system-token" {
+					return nil
+				}
+				return fmt.Errorf("token not supported")
+			},
+		}
+		regularProvider := &mockProvider{name: "regular", shouldSucceed: false}
+
+		ctx := context.WithValue(context.Background(), jwt.JWTContextKey, "ci-system-token")
+		_, err := Middleware(nonJWTProvider, regularProvider)(nopEndpoint)(ctx, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("JWT with matching issuer", func(t *testing.T) {
+		issuer := "https://example.com"
+		token := createJWTWithIssuer(issuer)
+
+		matchingProvider := &mockOidcProvider{
+			mockProvider: &mockProvider{
+				name:          "matching",
+				issuer:        issuer,
+				shouldSucceed: true,
+			},
+		}
+		nonMatchingProvider := &mockOidcProvider{
+			mockProvider: &mockProvider{
+				name:          "non-matching",
+				issuer:        "https://other.com",
+				shouldSucceed: false,
+			},
+		}
+
+		ctx := context.WithValue(context.Background(), jwt.JWTContextKey, token)
+		_, err := Middleware(nonMatchingProvider, matchingProvider)(nopEndpoint)(ctx, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("JWT with no matching provider fallback to all providers", func(t *testing.T) {
+		issuer := "https://example.com"
+		token := createJWTWithIssuer(issuer)
+
+		provider1 := &mockOidcProvider{
+			mockProvider: &mockProvider{
+				name:          "provider1",
+				issuer:        "https://other1.com",
+				shouldSucceed: false,
+			},
+		}
+		provider2 := &mockOidcProvider{
+			mockProvider: &mockProvider{
+				name:          "provider2",
+				issuer:        "https://other2.com",
+				shouldSucceed: true,
+			},
+		}
+
+		ctx := context.WithValue(context.Background(), jwt.JWTContextKey, token)
+		_, err := Middleware(provider1, provider2)(nopEndpoint)(ctx, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("malformed JWT fallback to all providers", func(t *testing.T) {
+		token := "malformed.jwt"
+
+		provider1 := &mockProvider{name: "provider1", shouldSucceed: false}
+		provider2 := &mockProvider{name: "provider2", shouldSucceed: true}
+
+		ctx := context.WithValue(context.Background(), jwt.JWTContextKey, token)
+		_, err := Middleware(provider1, provider2)(nopEndpoint)(ctx, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("non-JWT token try all providers", func(t *testing.T) {
+		token := "simple-token"
+
+		provider1 := &mockProvider{name: "provider1", shouldSucceed: false}
+		provider2 := &mockProvider{name: "provider2", shouldSucceed: true}
+
+		ctx := context.WithValue(context.Background(), jwt.JWTContextKey, token)
+		_, err := Middleware(provider1, provider2)(nopEndpoint)(ctx, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("all providers fail", func(t *testing.T) {
+		token := "invalid-token"
+
+		provider1 := &mockProvider{name: "provider1", shouldSucceed: false}
+		provider2 := &mockProvider{name: "provider2", shouldSucceed: false}
+
+		ctx := context.WithValue(context.Background(), jwt.JWTContextKey, token)
+		_, err := Middleware(provider1, provider2)(nopEndpoint)(ctx, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to verify token")
+	})
+
+	t.Run("JWT with matching issuer succeeds even when other providers fail", func(t *testing.T) {
+		issuer := "https://example.com"
+		token := createJWTWithIssuer(issuer)
+
+		failingProvider := &mockOidcProvider{
+			mockProvider: &mockProvider{
+				name:          "failing",
+				issuer:        "https://other.example.com",
+				shouldSucceed: false,
+			},
+		}
+		matchingProvider := &mockOidcProvider{
+			mockProvider: &mockProvider{
+				name:          "matching",
+				issuer:        issuer,
+				shouldSucceed: true,
+			},
+		}
+
+		ctx := context.WithValue(context.Background(), jwt.JWTContextKey, token)
+		_, err := Middleware(failingProvider, matchingProvider)(nopEndpoint)(ctx, nil)
+		assert.NoError(t, err)
+	})
+}
+
+func TestAuthMiddlewareWithStaticProvider(t *testing.T) {
 	t.Parallel()
 
 	type providerCase struct {

--- a/pkg/auth/provider_oidc.go
+++ b/pkg/auth/provider_oidc.go
@@ -2,31 +2,69 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 )
 
 type OidcProvider struct {
-	logger           *slog.Logger
-	issuer           string
-	clientIdentifier string
-	provider         *oidc.Provider
+	logger             *slog.Logger
+	issuer             string
+	clientIdentifier   string
+	provider           *oidc.Provider
+	acceptNonJWTTokens bool
 }
 
 func (p *OidcProvider) String() string { return "oidc" }
 
+type OidcConfig struct {
+	ClientID           string
+	Issuer             string
+	Scopes             []string
+	LoginGrants        []string
+	LoginPorts         []int
+	AcceptNonJWTTokens bool
+}
+
+func (o *OidcProvider) GetIssuer() string {
+	return o.issuer
+}
+
+func (o *OidcProvider) validateNonJWTToken(token string) error {
+	if token == "" {
+		return fmt.Errorf("empty token")
+	}
+
+	if len(token) < 10 {
+		return fmt.Errorf("token too short")
+	}
+
+	o.logger.Debug("accepting non-JWT token", slog.String("issuer", o.issuer))
+	return nil
+}
+
 // Unfortunately, it's difficult to write tests for this method, as we would need an OIDC Authorization Server
 // to generate valid signed JWTs
 func (o *OidcProvider) Verify(ctx context.Context, token string) error {
+	parts := strings.Split(token, ".")
+	isJWT := len(parts) == 3
+
+	if !isJWT && o.acceptNonJWTTokens {
+		return o.validateNonJWTToken(token)
+	}
+
+	if !isJWT {
+		return fmt.Errorf("token is not in JWT format and provider does not accept non-JWT tokens")
+	}
+
 	oidcConfig := &oidc.Config{
 		ClientID: o.clientIdentifier,
 	}
 	verifier := o.provider.VerifierContext(ctx, oidcConfig)
 
-	// Check method documentation to see what is verified and what not.
-	// The returned IdToken can be used to verify claims.
 	_, err := verifier.Verify(ctx, token)
 	return err
 }
@@ -39,7 +77,7 @@ func (o *OidcProvider) TokenURL() string {
 	return o.provider.Endpoint().TokenURL
 }
 
-func NewOidcProvider(ctx context.Context, issuer, clientIdentifier string) (*OidcProvider, error) {
+func NewOidcProvider(ctx context.Context, issuer, clientIdentifier string, acceptNonJWTTokens bool) (*OidcProvider, error) {
 	logger := slog.Default()
 	start := time.Now()
 	provider, err := oidc.NewProvider(ctx, issuer)
@@ -50,9 +88,10 @@ func NewOidcProvider(ctx context.Context, issuer, clientIdentifier string) (*Oid
 	logger.Info("finished initializing OIDC provider", slog.String("took", time.Since(start).String()))
 
 	return &OidcProvider{
-		logger:           logger,
-		issuer:           issuer,
-		clientIdentifier: clientIdentifier,
-		provider:         provider,
+		logger:             logger,
+		issuer:             issuer,
+		clientIdentifier:   clientIdentifier,
+		provider:           provider,
+		acceptNonJWTTokens: acceptNonJWTTokens,
 	}, nil
 }

--- a/pkg/auth/provider_oidc_test.go
+++ b/pkg/auth/provider_oidc_test.go
@@ -2,7 +2,9 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -35,8 +37,311 @@ func TestOidcProviderDiscovery(t *testing.T) {
 	defer s.Close()
 	issuer = s.URL
 
-	provider, err := NewOidcProvider(context.Background(), issuer, "boring-registry")
+	provider, err := NewOidcProvider(context.Background(), issuer, "boring-registry", false)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, provider.AuthURL())
 	assert.NotEmpty(t, provider.TokenURL())
+}
+
+func TestOidcProviderGetIssuer(t *testing.T) {
+	issuer := "https://example.com"
+	provider := &OidcProvider{
+		issuer: issuer,
+	}
+
+	assert.Equal(t, issuer, provider.GetIssuer())
+}
+
+func TestOidcProviderNonJWTTokenHandling(t *testing.T) {
+	tests := []struct {
+		name               string
+		acceptNonJWTTokens bool
+		token              string
+		expectError        bool
+	}{
+		{
+			name:               "Non-JWT token accepted when configured",
+			acceptNonJWTTokens: true,
+			token:              "non-jwt-token-from-ci-system",
+			expectError:        false,
+		},
+		{
+			name:               "Non-JWT token rejected when not configured",
+			acceptNonJWTTokens: false,
+			token:              "non-jwt-token-from-ci-system",
+			expectError:        true,
+		},
+		{
+			name:               "Empty token always rejected",
+			acceptNonJWTTokens: true,
+			token:              "",
+			expectError:        true,
+		},
+		{
+			name:               "Short token rejected",
+			acceptNonJWTTokens: true,
+			token:              "short",
+			expectError:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &OidcProvider{
+				logger:             slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelError})),
+				issuer:             "https://example.com",
+				acceptNonJWTTokens: tt.acceptNonJWTTokens,
+			}
+
+			err := provider.Verify(context.Background(), tt.token)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOidcProviderValidateNonJWTToken(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	provider := &OidcProvider{
+		logger: logger,
+		issuer: "https://example.com",
+	}
+
+	tests := []struct {
+		name        string
+		token       string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "valid token",
+			token:       "valid-ci-token-1234567890",
+			expectError: false,
+		},
+		{
+			name:        "empty token",
+			token:       "",
+			expectError: true,
+			errorMsg:    "empty token",
+		},
+		{
+			name:        "token too short",
+			token:       "short",
+			expectError: true,
+			errorMsg:    "token too short",
+		},
+		{
+			name:        "minimum length token",
+			token:       "1234567890",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := provider.validateNonJWTToken(tt.token)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOidcProviderVerify(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	t.Run("Non-JWT token validation", func(t *testing.T) {
+		provider := &OidcProvider{
+			logger:             logger,
+			issuer:             "https://example.com",
+			acceptNonJWTTokens: true,
+		}
+
+		err := provider.Verify(context.Background(), "valid-ci-token")
+		assert.NoError(t, err)
+
+		err = provider.Verify(context.Background(), "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "empty token")
+	})
+
+	t.Run("Regular OIDC token validation", func(t *testing.T) {
+		data := `{
+			"issuer": "ISSUER",
+			"authorization_endpoint": "/auth",
+			"token_endpoint": "/token",
+			"jwks_uri": "/keys",
+			"id_token_signing_alg_values_supported": ["RS256"]
+		}`
+
+		jwksData := `{
+			"keys": [
+				{
+					"kty": "RSA",
+					"use": "sig",
+					"kid": "test-key",
+					"n": "example-n",
+					"e": "AQAB"
+				}
+			]
+		}`
+
+		var issuer string
+		mux := http.NewServeMux()
+		mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, strings.ReplaceAll(data, "ISSUER", issuer))
+		})
+		mux.HandleFunc("/keys", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, jwksData)
+		})
+
+		s := httptest.NewServer(mux)
+		defer s.Close()
+		issuer = s.URL
+
+		provider, err := NewOidcProvider(context.Background(), issuer, "boring-registry", false)
+		assert.NoError(t, err)
+
+		err = provider.Verify(context.Background(), "invalid.jwt.token")
+		assert.Error(t, err)
+	})
+}
+
+func TestNewOidcProvider(t *testing.T) {
+	t.Run("successful provider creation", func(t *testing.T) {
+		data := `{
+			"issuer": "ISSUER",
+			"authorization_endpoint": "/auth",
+			"token_endpoint": "/token",
+			"jwks_uri": "/keys",
+			"id_token_signing_alg_values_supported": ["RS256"]
+		}`
+
+		var issuer string
+		hf := func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/.well-known/openid-configuration" {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, strings.ReplaceAll(data, "ISSUER", issuer))
+		}
+		s := httptest.NewServer(http.HandlerFunc(hf))
+		defer s.Close()
+		issuer = s.URL
+
+		provider, err := NewOidcProvider(context.Background(), issuer, "test-client-id", false)
+		assert.NoError(t, err)
+		assert.NotNil(t, provider)
+		assert.Equal(t, issuer, provider.GetIssuer())
+		assert.Equal(t, "test-client-id", provider.clientIdentifier)
+		assert.NotNil(t, provider.logger)
+		assert.NotNil(t, provider.provider)
+		assert.False(t, provider.acceptNonJWTTokens)
+	})
+
+	t.Run("failed provider creation invalid issuer", func(t *testing.T) {
+		provider, err := NewOidcProvider(context.Background(), "http://invalid-url-12345", "test-client-id", false)
+		assert.Error(t, err)
+		assert.Nil(t, provider)
+	})
+
+	t.Run("failed provider creation server error", func(t *testing.T) {
+		hf := func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+		s := httptest.NewServer(http.HandlerFunc(hf))
+		defer s.Close()
+
+		provider, err := NewOidcProvider(context.Background(), s.URL, "test-client-id", false)
+		assert.Error(t, err)
+		assert.Nil(t, provider)
+	})
+
+	t.Run("provider with non-JWT token support", func(t *testing.T) {
+		data := `{
+			"issuer": "ISSUER",
+			"authorization_endpoint": "/auth",
+			"token_endpoint": "/token",
+			"jwks_uri": "/keys",
+			"id_token_signing_alg_values_supported": ["RS256"]
+		}`
+
+		var issuer string
+		hf := func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/.well-known/openid-configuration" {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, strings.ReplaceAll(data, "ISSUER", issuer))
+		}
+		s := httptest.NewServer(http.HandlerFunc(hf))
+		defer s.Close()
+		issuer = s.URL
+
+		provider, err := NewOidcProvider(context.Background(), issuer, "test-client-id", true)
+		assert.NoError(t, err)
+		assert.NotNil(t, provider)
+		assert.True(t, provider.acceptNonJWTTokens)
+	})
+}
+
+func TestOidcProviderURLs(t *testing.T) {
+	data := `{
+		"issuer": "ISSUER",
+		"authorization_endpoint": "ISSUER/auth",
+		"token_endpoint": "ISSUER/token", 
+		"jwks_uri": "ISSUER/keys",
+		"id_token_signing_alg_values_supported": ["RS256"]
+	}`
+
+	var issuer string
+	hf := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, strings.ReplaceAll(data, "ISSUER", issuer))
+	}
+	s := httptest.NewServer(http.HandlerFunc(hf))
+	defer s.Close()
+	issuer = s.URL
+
+	provider, err := NewOidcProvider(context.Background(), issuer, "test-client", false)
+	assert.NoError(t, err)
+
+	authURL := provider.AuthURL()
+	tokenURL := provider.TokenURL()
+
+	assert.Equal(t, fmt.Sprintf("%s/auth", issuer), authURL)
+	assert.Equal(t, fmt.Sprintf("%s/token", issuer), tokenURL)
+}
+
+func TestOidcConfig(t *testing.T) {
+	config := OidcConfig{
+		ClientID:           "test-client-id",
+		Issuer:             "https://example.com",
+		Scopes:             []string{"openid", "profile"},
+		LoginGrants:        []string{"authorization_code"},
+		LoginPorts:         []int{10000, 10010},
+		AcceptNonJWTTokens: true,
+	}
+
+	assert.Equal(t, "test-client-id", config.ClientID)
+	assert.Equal(t, "https://example.com", config.Issuer)
+	assert.Equal(t, []string{"openid", "profile"}, config.Scopes)
+	assert.Equal(t, []string{"authorization_code"}, config.LoginGrants)
+	assert.Equal(t, []int{10000, 10010}, config.LoginPorts)
+	assert.True(t, config.AcceptNonJWTTokens)
 }


### PR DESCRIPTION
This adds support for multiple OIDC. When we deploy the service internally, we need different oidc for human users and our ci/cd agents.