### PR TITLE
docs: run mkdocs in container image locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ The docs can be rendered and served with `mkdocs serve` to preview changes live 
 
 ```shell
 docker build -f docs/Dockerfile -t boring-registry-docs .
-docker run --rm -it -p 8000:8000 -v ${PWD}:/docs boring-registry-docs serve -a 0.0.0.0:8000 --livereload
+docker run --rm -it -p 8000:8000 -v ${PWD}:/docs boring-registry-docs
 ```

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -3,3 +3,5 @@ FROM squidfunk/mkdocs-material:9.6.21@sha256:00f9276315990b82f5af8c47bb2b71e2c69
 WORKDIR /docs
 COPY docs/requirements.txt /docs/requirements.txt
 RUN pip install --no-cache-dir -r /docs/requirements.txt
+
+CMD ["serve", "--dev-addr=0.0.0.0:8000", "--livereload"]


### PR DESCRIPTION
Some minimal instructions to run mkdocs in a container image