### PR TITLE
test(module): increase test coverage and return error if version is missing

### DIFF
--- a/cmd/uploadmodule.go
+++ b/cmd/uploadmodule.go
@@ -200,7 +200,10 @@ func (m *moduleUploadRunner) processModule(path string) error {
 	}
 
 	if m.config.versionConstraintsRegex != nil {
-		if !spec.MeetsRegexConstraints(m.config.versionConstraintsRegex) {
+		ok, err := spec.MeetsRegexConstraints(m.config.versionConstraintsRegex)
+		if err != nil {
+			return err
+		} else if !ok {
 			// Skip the module, as it didn't pass the regex version constraints
 			slog.Info("module doesn't meet regex version constraints, skipped", slog.String("name", spec.Name()))
 			return nil

--- a/pkg/module/parser.go
+++ b/pkg/module/parser.go
@@ -86,8 +86,11 @@ func (s *Spec) MeetsSemverConstraints(constraints version.Constraints) (bool, er
 
 // MeetsRegexConstraints checks whether a module version matches the regex.
 // Returns a boolean indicating if the module meets the constraints
-func (s *Spec) MeetsRegexConstraints(re *regexp.Regexp) bool {
-	return re.MatchString(s.Metadata.Version)
+func (s *Spec) MeetsRegexConstraints(re *regexp.Regexp) (bool, error) {
+	if s.Metadata.Version == "" {
+		return false, errors.New("version is unset")
+	}
+	return re.MatchString(s.Metadata.Version), nil
 }
 
 // ParseFile parses a module spec file.


### PR DESCRIPTION
* return error in case `Spec.Metadata.Version` is missing when evaluating regex constraints
* Increase test coverage