### PR TITLE
Update Go base image version to 1.25.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ARG before first stage to share the value across multiple stages
 ARG BASEDIR=/go/src/github.com/boring-registry/boring-registry
 
-FROM golang:1.25 AS build
+FROM golang:1.25.5 AS build
 
 ARG VERSION
 ARG GIT_COMMIT


### PR DESCRIPTION
We found the following CVEs with our deployment:

CVE-2025-58187 
CVE-2025-58188 
CVE-2025-61723
CVE-2025-61725

They are fixed after 1.25.3

This PR is to upgrade the golang version to patch the vulnerabilities.

