### PR TITLE
Support parsing provider data without any signing keys

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/boring-registry/boring-registry/pkg/core"
 	"github.com/boring-registry/boring-registry/pkg/mirror"
@@ -35,13 +34,13 @@ func unmarshalSigningKeys(b []byte) (*core.SigningKeys, error) {
 	// Therefore, we try to unmarshal into core.GPGPublicKey format for legacy reasons.
 	if signingKeys.GPGPublicKeys == nil {
 		var gpgPublicKey core.GPGPublicKey
+		signingKeys.GPGPublicKeys = []core.GPGPublicKey{}
 		if gpgPublicKeyErr := json.Unmarshal(b, &gpgPublicKey); gpgPublicKeyErr != nil {
 			return nil, gpgPublicKeyErr
-		} else if gpgPublicKey.KeyID == "" || gpgPublicKey.ASCIIArmor == "" {
-			return nil, fmt.Errorf("the signing key key_ID or ascii_armor is empty")
+		} else if gpgPublicKey.KeyID != "" && gpgPublicKey.ASCIIArmor != "" {
+			signingKeys.GPGPublicKeys = append(signingKeys.GPGPublicKeys, gpgPublicKey)
 		}
 
-		signingKeys.GPGPublicKeys = append(signingKeys.GPGPublicKeys, gpgPublicKey)
 	}
 
 	return &signingKeys, nil

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -1,0 +1,86 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/boring-registry/boring-registry/pkg/core"
+
+	assertion "github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalSigningKeys(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		body        string
+		expected    []core.GPGPublicKey
+		expectError bool
+	}{
+		{
+			name:        "invalid json",
+			body:        `not json`,
+			expectError: true,
+		},
+		{
+			name:     "empty gpg_public_keys",
+			body:     `{"gpg_public_keys":[]}`,
+			expected: []core.GPGPublicKey{},
+		},
+		{
+			name:     "empty object",
+			body:     `{}`,
+			expected: []core.GPGPublicKey{},
+		},
+		{
+			name: "core.SigningKeys format",
+			body: `{"gpg_public_keys":[{"key_id":"51852D87348FFC4C","ascii_armor":"-----BEGIN PGP PUBLIC KEY BLOCK-----"}]}`,
+			expected: []core.GPGPublicKey{
+				{
+					KeyID:      "51852D87348FFC4C",
+					ASCIIArmor: "-----BEGIN PGP PUBLIC KEY BLOCK-----",
+				},
+			},
+		},
+		{
+			name: "legacy core.GPGPublicKey format",
+			body: `{"key_id":"51852D87348FFC4C","ascii_armor":"-----BEGIN PGP PUBLIC KEY BLOCK-----"}`,
+			expected: []core.GPGPublicKey{
+				{
+					KeyID:      "51852D87348FFC4C",
+					ASCIIArmor: "-----BEGIN PGP PUBLIC KEY BLOCK-----",
+				},
+			},
+		},
+		{
+			// The signing keys are needed to mirror a provider, so an incomplete
+			// legacy document has to unmarshal into an empty set instead of failing
+			name:     "legacy core.GPGPublicKey format without ascii_armor",
+			body:     `{"key_id":"51852D87348FFC4C"}`,
+			expected: []core.GPGPublicKey{},
+		},
+		{
+			name:     "legacy core.GPGPublicKey format without key_id",
+			body:     `{"ascii_armor":"-----BEGIN PGP PUBLIC KEY BLOCK-----"}`,
+			expected: []core.GPGPublicKey{},
+		},
+	}
+
+	assert := assertion.New(t)
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			signingKeys, err := unmarshalSigningKeys([]byte(tc.body))
+			if tc.expectError {
+				assert.Error(err)
+				return
+			}
+
+			assert.NoError(err)
+			if !assert.NotNil(signingKeys) {
+				return
+			}
+			assert.Equal(tc.expected, signingKeys.GPGPublicKeys)
+		})
+	}
+}


### PR DESCRIPTION
While switching to the pull-through mirror, I started seeing failure. As it turns out some providers don't have signing keys, at least on opentofu registry (Such as this one: http://registry.opentofu.org/v1/providers/cyrilgdn/rabbitmq/1.9.0/download/linux/arm64 ). 

This PR change the behavior to not fail on empty key, and instead just keep the list empty.