### PR TITLE
test: add --skipApiVersionCheck argument to azurite container

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/azure v0.40.0
 	golang.org/x/oauth2 v0.31.0
 	golang.org/x/sync v0.17.0
@@ -140,7 +141,6 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/testcontainers/testcontainers-go v0.40.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -11,6 +11,7 @@ import (
 	"github.com/boring-registry/boring-registry/pkg/storage"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/azure/azurite"
 )
 
@@ -46,7 +47,14 @@ func (s *storageHarness) setupClient(ctx context.Context, t *testing.T) {
 }
 
 func (s *storageHarness) createAzuriteContainer(ctx context.Context, t *testing.T) func() {
-	azuriteContainer, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.35.0")
+	azuriteContainer, err := azurite.Run(ctx,
+		"mcr.microsoft.com/azure-storage/azurite:3.35.0",
+
+		// The Azurite release schedule sometimes lags behind the release schedule of azure-sdk-for-go.
+		// This can result in situations where the API schema in azure-sdk-for-go is more recent as azurite's.
+		// THerefore we skip the API version check
+		testcontainers.WithCmdArgs("--skipApiVersionCheck"),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The Azurite release schedule sometimes lags behind the release schedule of azure-sdk-for-go. This can result in situations where the API schema in azure-sdk-for-go is more recent as azurite's. Therefore we skip the API version check for the integration test