### PR TITLE
fix: reuse IamCredentialsClient to prevent memory leak in GCS storage

### DIFF
--- a/pkg/storage/gcs.go
+++ b/pkg/storage/gcs.go
@@ -439,7 +439,7 @@ func (s *GCSStorage) GetDownloadUrl(ctx context.Context, url string) (string, er
 }
 
 // Close releases any resources held by the GCSStorage.
-// Note: This is not currently called anywhere in the codebase, but it should 
+// Note: This is not currently called anywhere in the codebase, but it should
 // be invoked during process termination to ensure all clients are closed gracefully.
 func (s *GCSStorage) Close() error {
 	var errs []error


### PR DESCRIPTION
The presignedURL function was creating a new IamCredentialsClient for every call without closing it. This caused a gRPC connection leak that accumulated significant memory over time during heavy mirroring operations. Changes:
- Store IamCredentialsClient in GCSStorage struct
- Initialize client once in NewGCSStorage() when service account is configured
- Add Close() method for proper resource cleanup

The new `Close()` method is never called on storage, but at least we have the option to do it now, makes sense?