### PR TITLE
minor: support for skipping oidc client id check in jwts

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -65,6 +65,7 @@ var (
 	flagAuthOidcIssuer   string
 	flagAuthOidcClientId string
 	flagAuthOidcScopes   []string
+	flagAuthOidcSkipClientIDCheck bool
 
 	// Okta auth
 	flagAuthOktaIssuer   string
@@ -205,6 +206,7 @@ func init() {
 	serverCmd.Flags().StringVar(&flagAuthOidcIssuer, "auth-oidc-issuer", "", "OIDC issuer URL")
 	serverCmd.Flags().StringVar(&flagAuthOidcClientId, "auth-oidc-clientid", "", "OIDC client identifier")
 	serverCmd.Flags().StringSliceVar(&flagAuthOidcScopes, "auth-oidc-scopes", nil, "List of OAuth2 scopes")
+	serverCmd.Flags().BoolVar(&flagAuthOidcSkipClientIDCheck, "auth-oidc-skip-client-id-check", false, "Skip client id check during JWT verification. (Default: false)")
 
 	// Terraform Login Protocol options.
 	serverCmd.Flags().StringVar(&flagAuthOktaClientId, "login-client", "", "The client_id value to use when making requests")
@@ -284,7 +286,13 @@ func setupOidc(ctx context.Context) (auth.Provider, *discovery.LoginV1, error) {
 		slog.Any("scopes", flagAuthOidcScopes),
 	)
 
-	provider, err := auth.NewOidcProvider(authCtx, flagAuthOidcIssuer, flagAuthOidcClientId)
+	var oidcProviderOptions []auth.OidcProviderOption
+
+	if (flagAuthOidcSkipClientIDCheck) {
+		oidcProviderOptions = append(oidcProviderOptions, auth.WithSkipClientIDCheck)
+	}
+
+	provider, err := auth.NewOidcProvider(authCtx, flagAuthOidcIssuer, flagAuthOidcClientId, oidcProviderOptions...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to set up oidc provider: %w", err)
 	}

--- a/pkg/auth/provider_oidc.go
+++ b/pkg/auth/provider_oidc.go
@@ -13,15 +13,17 @@ type OidcProvider struct {
 	issuer           string
 	clientIdentifier string
 	provider         *oidc.Provider
+	skipClientIDCheck bool
 }
 
 func (p *OidcProvider) String() string { return "oidc" }
 
 // Unfortunately, it's difficult to write tests for this method, as we would need an OIDC Authorization Server
 // to generate valid signed JWTs
-func (o *OidcProvider) Verify(ctx context.Context, token string) error {
+func (o *OidcProvider) Verify(ctx context.Context, token string) error {	
 	oidcConfig := &oidc.Config{
 		ClientID: o.clientIdentifier,
+		SkipClientIDCheck: o.skipClientIDCheck,
 	}
 	verifier := o.provider.VerifierContext(ctx, oidcConfig)
 
@@ -39,7 +41,14 @@ func (o *OidcProvider) TokenURL() string {
 	return o.provider.Endpoint().TokenURL
 }
 
-func NewOidcProvider(ctx context.Context, issuer, clientIdentifier string) (*OidcProvider, error) {
+type OidcProviderOption func(*OidcProvider) *OidcProvider
+
+func WithSkipClientIDCheck(oidcProvider *OidcProvider) *OidcProvider {
+	oidcProvider.skipClientIDCheck = true
+	return oidcProvider
+}
+
+func NewOidcProvider(ctx context.Context, issuer, clientIdentifier string, options ...OidcProviderOption) (*OidcProvider, error) {
 	logger := slog.Default()
 	start := time.Now()
 	provider, err := oidc.NewProvider(ctx, issuer)
@@ -49,10 +58,16 @@ func NewOidcProvider(ctx context.Context, issuer, clientIdentifier string) (*Oid
 
 	logger.Info("finished initializing OIDC provider", slog.String("took", time.Since(start).String()))
 
-	return &OidcProvider{
+	oidcProvider := &OidcProvider{
 		logger:           logger,
 		issuer:           issuer,
 		clientIdentifier: clientIdentifier,
 		provider:         provider,
-	}, nil
+	}
+
+	for _, optionFunc := range options {
+		optionFunc(oidcProvider)
+	}
+
+	return oidcProvider, nil
 }


### PR DESCRIPTION
This PR adds an additional `--auth-oidc-skip-client-id-check` bool flag to `boring-registry server` command. It defaults to `false` which effectively makes the new behavior "opt in".

The purpose of needing this flag is to support the use of the Okta org wide authorization servers when configuring generic OIDC settings with boring-registry. Any token minted by the org wide okta authorization server will always have an `aud` claim value of `https://name-of-tenant.okta.com/`. That behavior will always conflict with the JWT verification in boring-registry server since it expects the `aud` claim to match the client id of the OIDC app used.

This PR addresses an issue I raised https://github.com/boring-registry/boring-registry/issues/343