### PR TITLE
fix: add timeout to upstream HTTP client

### DIFF
--- a/pkg/mirror/upstream.go
+++ b/pkg/mirror/upstream.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/boring-registry/boring-registry/pkg/core"
 	"github.com/boring-registry/boring-registry/pkg/discovery"
@@ -104,6 +105,7 @@ func newUpstreamProviderRegistry(remoteServiceDiscovery discovery.ServiceDiscove
 	return &upstreamProviderRegistry{
 		client: &http.Client{
 			Transport: transport,
+			Timeout:   30 * time.Second,
 		},
 		remoteServiceDiscovery: remoteServiceDiscovery,
 	}


### PR DESCRIPTION
## Problem

The upstream provider registry HTTP client (`newUpstreamProviderRegistry`) is created with no `Timeout` field. It relies entirely on context-based cancellation, but `getProvider()` and `shaSums()` in the `RetrieveProviderArchive` code path inherit the parent request context without adding a per-call timeout. A hung upstream connection can block the handler goroutine indefinitely.

## Fix

Add a 30-second client-level `Timeout` as a safety net. This is generous enough to never interfere with normal upstream API calls (metadata lookups, not archive downloads — those use the copier's own client with a 2-minute timeout), while preventing indefinite hangs.

Existing per-request context timeouts (e.g. the 10s timeout in `ListProviderVersions`) will still fire first where they are set.