### PR TITLE
fix: increase server WriteTimeout to prevent premature connection termination

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -96,14 +96,14 @@ var serverCmd = &cobra.Command{
 		server := &http.Server{
 			Addr:         flagListenAddr,
 			ReadTimeout:  5 * time.Second,
-			WriteTimeout: 5 * time.Second,
+			WriteTimeout: 60 * time.Second,
 			Handler:      mux,
 		}
 
 		telemetryServer := &http.Server{
 			Addr:         flagTelemetryListenAddr,
 			ReadTimeout:  5 * time.Second,
-			WriteTimeout: 5 * time.Second,
+			WriteTimeout: 10 * time.Second,
 			Handler:      mux,
 		}
 


### PR DESCRIPTION
## Problem

The main HTTP server's `WriteTimeout` is set to 5 seconds, but the pull-through mirror handlers (`ListProviderVersions`, `ListProviderInstallation`) create 10-second context timeouts for upstream registry API calls.

When an upstream call takes longer than 5 seconds, the server terminates the TCP connection before the handler finishes writing the response. This manifests as upstream connection termination (UC) errors in reverse proxies sitting in front of boring-registry.

## Fix

- Increase `WriteTimeout` to **60s** on the main server (port 5601). The actual request deadlines are enforced by per-handler context timeouts, not `WriteTimeout` — it only needs to be large enough to not interfere.
- Increase `WriteTimeout` to **10s** on the telemetry server (port 7801), which only serves `/metrics` and pprof endpoints.