### PR TITLE
fix: deduplicate concurrent pull-through copy operations with singleflight

### DIFF
--- a/pkg/mirror/copier.go
+++ b/pkg/mirror/copier.go
@@ -13,7 +13,7 @@ import (
 
 type Copier interface {
 	// copy copies the artifacts of a provider to the pull-through cache/mirror
-	copy(provider *core.Provider)
+	copy(provider *core.Provider) error
 }
 
 // copier implements Copier and ensures that requested providers are replicated to the internal storage asynchronously
@@ -27,7 +27,7 @@ type copier struct {
 }
 
 // copy should be started in a separate goroutine
-func (c *copier) copy(provider *core.Provider) {
+func (c *copier) copy(provider *core.Provider) error {
 	begin := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
@@ -46,29 +46,29 @@ func (c *copier) copy(provider *core.Provider) {
 	// We download the files from upstream and mirror them to our storage
 	if err := c.signingKeys(ctx, provider); err != nil {
 		c.logger.Error("failed to copy signing keys", logKeyValues(provider), slog.String("err", err.Error()))
-		return
+		return fmt.Errorf("failed to copy signing keys: %w", err)
 	}
 
 	if err := c.sha256Sums(ctx, provider); err != nil {
 		c.logger.Error("failed to copy SHA256SUMS", logKeyValues(provider), slog.String("err", err.Error()))
-		return
+		return fmt.Errorf("failed to copy SHA256SUMS: %w", err)
 	}
 
 	if err := c.sha256SumsSignature(ctx, provider); err != nil {
 		c.logger.Error("failed to copy SHA256SUMS.sig", logKeyValues(provider), slog.String("err", err.Error()))
-		return
+		return fmt.Errorf("failed to copy SHA256SUMS.sig: %w", err)
 	}
 
 	// Request the provider archive
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, provider.DownloadURL, nil)
 	if err != nil {
 		c.logger.Error("failed to create provider download request", logKeyValues(provider), slog.String("err", err.Error()))
-		return
+		return fmt.Errorf("failed to create provider download request: %w", err)
 	}
 	resp, err := c.client.Do(req)
 	if err != nil {
 		c.logger.Error("failed to download provider", logKeyValues(provider), slog.String("err", err.Error()))
-		return
+		return fmt.Errorf("failed to download provider: %w", err)
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -79,8 +79,10 @@ func (c *copier) copy(provider *core.Provider) {
 	fileName := provider.ArchiveFileName()
 	if err = c.storage.UploadMirroredFile(ctx, provider, fileName, resp.Body); err != nil {
 		c.logger.Error("failed to upload provider to mirror", logKeyValues(provider), slog.String("err", err.Error()))
+		return fmt.Errorf("failed to upload provider to mirror: %w", err)
 	}
 	c.logger.Info("successfully copied provider", logKeyValues(provider), slog.String("took", time.Since(begin).String()))
+	return nil
 }
 
 // check if the signing keys exist, if not add it

--- a/pkg/mirror/service.go
+++ b/pkg/mirror/service.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/boring-registry/boring-registry/pkg/core"
 	"github.com/boring-registry/boring-registry/pkg/discovery"
+
+	"golang.org/x/sync/singleflight"
 )
 
 // Service implements the Provider Network Mirror Protocol.
@@ -79,9 +81,10 @@ func NewMirror(s Storage) Service {
 }
 
 type pullThroughMirror struct {
-	upstream upstreamProvider
-	mirror   Service
-	copier   Copier
+	upstream  upstreamProvider
+	mirror    Service
+	copier    Copier
+	copyGroup singleflight.Group
 }
 
 func (p *pullThroughMirror) ListProviderVersions(ctx context.Context, provider *core.Provider) (*ListProviderVersionsResponse, error) {
@@ -151,8 +154,13 @@ func (p *pullThroughMirror) RetrieveProviderArchive(ctx context.Context, provide
 		return nil, err
 	}
 
-	// Download the provider from upstream and upload to the mirror
-	go p.copier.copy(upstream)
+	// Download the provider from upstream and upload to the mirror.
+	// Use singleflight to deduplicate concurrent copy operations for the same provider,
+	// preventing redundant downloads and uploads under thundering herd conditions.
+	copyKey := fmt.Sprintf("%s/%s/%s/%s/%s/%s", provider.Hostname, provider.Namespace, provider.Name, provider.Version, provider.OS, provider.Arch)
+	go p.copyGroup.Do(copyKey, func() (interface{}, error) {
+		return nil, p.copier.copy(upstream)
+	})
 
 	return &retrieveProviderArchiveResponse{
 		location:     upstream.DownloadURL,

--- a/pkg/mirror/service_test.go
+++ b/pkg/mirror/service_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/url"
 	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -62,6 +64,14 @@ func (m *mockedStorage) UploadMirroredSigningKeys(ctx context.Context, hostname,
 
 func (m *mockedStorage) MirroredSha256Sum(ctx context.Context, provider *core.Provider) (*core.Sha256Sums, error) {
 	return m.mirroredSha256Sum(ctx, provider)
+}
+
+type mockedCopier struct {
+	customCopy func(provider *core.Provider) error
+}
+
+func (m *mockedCopier) copy(provider *core.Provider) error {
+	return m.customCopy(provider)
 }
 
 func Test_pullThroughMirror_ListProviderVersions(t *testing.T) {
@@ -604,14 +614,14 @@ func Test_pullThroughCache_RetrieveProviderArchive(t *testing.T) {
 	}
 	tests := []struct {
 		name    string
-		svc     pullThroughMirror
+		svc     *pullThroughMirror
 		args    args
 		want    *retrieveProviderArchiveResponse
 		wantErr bool
 	}{
 		{
 			name: "provider exists in the mirror",
-			svc: pullThroughMirror{
+			svc: &pullThroughMirror{
 				mirror: &mirror{
 					storage: &mockedStorage{
 						getMirroredProvider: func(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
@@ -637,7 +647,7 @@ func Test_pullThroughCache_RetrieveProviderArchive(t *testing.T) {
 		},
 		{
 			name: "a non-core.ProviderError happened while looking up the provider in the mirror",
-			svc: pullThroughMirror{
+			svc: &pullThroughMirror{
 				mirror: &mirror{
 					storage: &mockedStorage{
 						getMirroredProvider: func(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
@@ -650,7 +660,7 @@ func Test_pullThroughCache_RetrieveProviderArchive(t *testing.T) {
 		},
 		{
 			name: "error when retrieving the provider from upstram",
-			svc: pullThroughMirror{
+			svc: &pullThroughMirror{
 				upstream: &mockedUpstreamProvider{
 					customGetProvider: func(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
 						return nil, errors.New("mocked error")
@@ -683,5 +693,73 @@ func Test_pullThroughCache_RetrieveProviderArchive(t *testing.T) {
 				t.Errorf("RetrieveProviderArchive() got = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func Test_pullThroughMirror_RetrieveProviderArchive_Singleflight(t *testing.T) {
+	var copyCount atomic.Int64
+
+	svc := &pullThroughMirror{
+		upstream: &mockedUpstreamProvider{
+			customGetProvider: func(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
+				return &core.Provider{
+					Hostname:    "registry.terraform.io",
+					Namespace:   "integrations",
+					Name:        "github",
+					Version:     "5.45.0",
+					OS:          "linux",
+					Arch:        "amd64",
+					DownloadURL: "https://releases.hashicorp.com/terraform-provider-github/5.45.0/terraform-provider-github_5.45.0_linux_amd64.zip",
+				}, nil
+			},
+		},
+		mirror: &mirror{
+			storage: &mockedStorage{
+				getMirroredProvider: func(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
+					// Provider is not in the mirror, triggering the copy path
+					return nil, &core.ProviderError{Reason: "not found"}
+				},
+			},
+		},
+		copier: &mockedCopier{
+			customCopy: func(provider *core.Provider) error {
+				copyCount.Add(1)
+				// Simulate a slow copy operation
+				time.Sleep(100 * time.Millisecond)
+				return nil
+			},
+		},
+	}
+
+	const concurrency = 10
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+
+	provider := &core.Provider{
+		Hostname:  "registry.terraform.io",
+		Namespace: "integrations",
+		Name:      "github",
+		Version:   "5.45.0",
+		OS:        "linux",
+		Arch:      "amd64",
+	}
+
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := svc.RetrieveProviderArchive(context.Background(), provider)
+			if err != nil {
+				t.Errorf("RetrieveProviderArchive() unexpected error: %v", err)
+			}
+		}()
+	}
+
+	wg.Wait()
+	// Wait for the background singleflight goroutine to complete
+	time.Sleep(200 * time.Millisecond)
+
+	got := copyCount.Load()
+	if got != 1 {
+		t.Errorf("expected copier.copy to be called exactly 1 time, got %d", got)
 	}
 }

--- a/vendor/golang.org/x/sync/singleflight/singleflight.go
+++ b/vendor/golang.org/x/sync/singleflight/singleflight.go
@@ -1,0 +1,214 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package singleflight provides a duplicate function call suppression
+// mechanism.
+package singleflight // import "golang.org/x/sync/singleflight"
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"sync"
+)
+
+// errGoexit indicates the runtime.Goexit was called in
+// the user given function.
+var errGoexit = errors.New("runtime.Goexit was called")
+
+// A panicError is an arbitrary value recovered from a panic
+// with the stack trace during the execution of given function.
+type panicError struct {
+	value interface{}
+	stack []byte
+}
+
+// Error implements error interface.
+func (p *panicError) Error() string {
+	return fmt.Sprintf("%v\n\n%s", p.value, p.stack)
+}
+
+func (p *panicError) Unwrap() error {
+	err, ok := p.value.(error)
+	if !ok {
+		return nil
+	}
+
+	return err
+}
+
+func newPanicError(v interface{}) error {
+	stack := debug.Stack()
+
+	// The first line of the stack trace is of the form "goroutine N [status]:"
+	// but by the time the panic reaches Do the goroutine may no longer exist
+	// and its status will have changed. Trim out the misleading line.
+	if line := bytes.IndexByte(stack[:], '\n'); line >= 0 {
+		stack = stack[line+1:]
+	}
+	return &panicError{value: v, stack: stack}
+}
+
+// call is an in-flight or completed singleflight.Do call
+type call struct {
+	wg sync.WaitGroup
+
+	// These fields are written once before the WaitGroup is done
+	// and are only read after the WaitGroup is done.
+	val interface{}
+	err error
+
+	// These fields are read and written with the singleflight
+	// mutex held before the WaitGroup is done, and are read but
+	// not written after the WaitGroup is done.
+	dups  int
+	chans []chan<- Result
+}
+
+// Group represents a class of work and forms a namespace in
+// which units of work can be executed with duplicate suppression.
+type Group struct {
+	mu sync.Mutex       // protects m
+	m  map[string]*call // lazily initialized
+}
+
+// Result holds the results of Do, so they can be passed
+// on a channel.
+type Result struct {
+	Val    interface{}
+	Err    error
+	Shared bool
+}
+
+// Do executes and returns the results of the given function, making
+// sure that only one execution is in-flight for a given key at a
+// time. If a duplicate comes in, the duplicate caller waits for the
+// original to complete and receives the same results.
+// The return value shared indicates whether v was given to multiple callers.
+func (g *Group) Do(key string, fn func() (interface{}, error)) (v interface{}, err error, shared bool) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		g.mu.Unlock()
+		c.wg.Wait()
+
+		if e, ok := c.err.(*panicError); ok {
+			panic(e)
+		} else if c.err == errGoexit {
+			runtime.Goexit()
+		}
+		return c.val, c.err, true
+	}
+	c := new(call)
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	g.doCall(c, key, fn)
+	return c.val, c.err, c.dups > 0
+}
+
+// DoChan is like Do but returns a channel that will receive the
+// results when they are ready.
+//
+// The returned channel will not be closed.
+func (g *Group) DoChan(key string, fn func() (interface{}, error)) <-chan Result {
+	ch := make(chan Result, 1)
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		c.chans = append(c.chans, ch)
+		g.mu.Unlock()
+		return ch
+	}
+	c := &call{chans: []chan<- Result{ch}}
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	go g.doCall(c, key, fn)
+
+	return ch
+}
+
+// doCall handles the single call for a key.
+func (g *Group) doCall(c *call, key string, fn func() (interface{}, error)) {
+	normalReturn := false
+	recovered := false
+
+	// use double-defer to distinguish panic from runtime.Goexit,
+	// more details see https://golang.org/cl/134395
+	defer func() {
+		// the given function invoked runtime.Goexit
+		if !normalReturn && !recovered {
+			c.err = errGoexit
+		}
+
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		c.wg.Done()
+		if g.m[key] == c {
+			delete(g.m, key)
+		}
+
+		if e, ok := c.err.(*panicError); ok {
+			// In order to prevent the waiting channels from being blocked forever,
+			// needs to ensure that this panic cannot be recovered.
+			if len(c.chans) > 0 {
+				go panic(e)
+				select {} // Keep this goroutine around so that it will appear in the crash dump.
+			} else {
+				panic(e)
+			}
+		} else if c.err == errGoexit {
+			// Already in the process of goexit, no need to call again
+		} else {
+			// Normal return
+			for _, ch := range c.chans {
+				ch <- Result{c.val, c.err, c.dups > 0}
+			}
+		}
+	}()
+
+	func() {
+		defer func() {
+			if !normalReturn {
+				// Ideally, we would wait to take a stack trace until we've determined
+				// whether this is a panic or a runtime.Goexit.
+				//
+				// Unfortunately, the only way we can distinguish the two is to see
+				// whether the recover stopped the goroutine from terminating, and by
+				// the time we know that, the part of the stack trace relevant to the
+				// panic has been discarded.
+				if r := recover(); r != nil {
+					c.err = newPanicError(r)
+				}
+			}
+		}()
+
+		c.val, c.err = fn()
+		normalReturn = true
+	}()
+
+	if !normalReturn {
+		recovered = true
+	}
+}
+
+// Forget tells the singleflight to forget about a key.  Future calls
+// to Do for this key will call the function rather than waiting for
+// an earlier call to complete.
+func (g *Group) Forget(key string) {
+	g.mu.Lock()
+	delete(g.m, key)
+	g.mu.Unlock()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -759,8 +759,6 @@ github.com/shirou/gopsutil/v4/process
 # github.com/sirupsen/logrus v1.9.3
 ## explicit; go 1.13
 github.com/sirupsen/logrus
-# github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8
-## explicit; go 1.20
 # github.com/spf13/afero v1.15.0
 ## explicit; go 1.23.0
 github.com/spf13/afero
@@ -949,6 +947,7 @@ golang.org/x/oauth2/jwt
 ## explicit; go 1.24.0
 golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
+golang.org/x/sync/singleflight
 # golang.org/x/sys v0.40.0
 ## explicit; go 1.24.0
 golang.org/x/sys/cpu


### PR DESCRIPTION
## Problem

When multiple Terraform clients request the same uncached provider simultaneously (thundering herd), each cache miss in `RetrieveProviderArchive` fires a separate `go p.copier.copy(upstream)` goroutine. Each goroutine independently downloads the provider archive from upstream and uploads it to storage. With N concurrent requests, this means N parallel downloads and N parallel uploads for the exact same artifact.

## Fix

Add a `singleflight.Group` to `pullThroughMirror`. The copy goroutine is now keyed by `hostname/namespace/name/version/os/arch`, so concurrent requests for the same provider share a single in-flight copy operation. The first request triggers the copy; subsequent requests for the same key wait for the result.

Also changes `Copier.copy` to return `error` (previously void) so the singleflight wrapper and future callers can observe failures. The `Copier` interface is unexported and only used within the `mirror` package.

`golang.org/x/sync` was already a dependency in `go.mod` — this just vendors the `singleflight` sub-package.

## Testing

Added `Test_pullThroughMirror_RetrieveProviderArchive_Singleflight`: fires 10 concurrent `RetrieveProviderArchive` calls for the same uncached provider and asserts that `copier.copy` is invoked exactly once.