### PR TITLE
fix(mirror): limit concurrent copy operations with a semaphore

### DIFF
--- a/pkg/mirror/copier.go
+++ b/pkg/mirror/copier.go
@@ -21,6 +21,9 @@ type copier struct {
 	// done is used to signal termination to potentially multiple goroutines at once
 	done chan struct{}
 
+	// sem limits the number of concurrent copy operations
+	sem chan struct{}
+
 	storage Storage
 	client  *http.Client
 	logger  *slog.Logger
@@ -28,6 +31,16 @@ type copier struct {
 
 // copy should be started in a separate goroutine
 func (c *copier) copy(provider *core.Provider) {
+	// Acquire a semaphore slot to limit concurrent copy operations.
+	// If the copier is shutting down, abort immediately.
+	select {
+	case c.sem <- struct{}{}:
+		defer func() { <-c.sem }()
+	case <-c.done:
+		c.logger.Warn("copier is shutting down, skipping copy", logKeyValues(provider))
+		return
+	}
+
 	begin := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
@@ -160,6 +173,7 @@ func NewCopier(ctx context.Context, storage Storage) Copier {
 	logger := slog.Default().With(slog.String("component", "copier"))
 	m := &copier{
 		done:   make(chan struct{}),
+		sem:    make(chan struct{}, 10),
 		logger: logger,
 		client: &http.Client{
 			// This is also the timeout for reading the response body


### PR DESCRIPTION
## Problem

The pull-through mirror copier spawns a new goroutine for every cache miss via `go p.copier.copy(upstream)` with no concurrency limit. Each goroutine downloads a provider archive from upstream and uploads it to storage. Under thundering herd conditions (many concurrent cache misses for *different* providers), this can lead to unbounded goroutine growth, exhausting memory and file descriptors.

## Fix

Add a channel-based semaphore (capacity 10) to the `copier` struct. Each `copy` call must acquire a slot before proceeding. Excess copy operations queue until a slot becomes available. If the copier is shutting down (`done` channel closed), queued copies are aborted immediately.

The limit of 10 concurrent copies is a conservative default — enough to keep the cache warm under normal load without overwhelming upstream registries or local resources.