### PR TITLE
fix: check HTTP status code in upstream shaSums response

### DIFF
--- a/pkg/mirror/upstream.go
+++ b/pkg/mirror/upstream.go
@@ -91,6 +91,10 @@ func (u *upstreamProviderRegistry) shaSums(ctx context.Context, provider *core.P
 		_ = resp.Body.Close()
 	}()
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to download SHA256SUMS from upstream, status code: %d", resp.StatusCode)
+	}
+
 	sha256Sums, err := core.NewSha256Sums(provider.ShasumFileName(), resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse SHA256SUM: %w", err)

--- a/pkg/mirror/upstream_test.go
+++ b/pkg/mirror/upstream_test.go
@@ -210,13 +210,15 @@ func Test_upstreamProviderRegistry_getProvider(t *testing.T) {
 
 func Test_upstreamProviderRegistry_shaSums(t *testing.T) {
 	tests := []struct {
-		name     string
-		provider *core.Provider
-		want     *core.Sha256Sums
-		wantErr  bool
+		name       string
+		statusCode int
+		provider   *core.Provider
+		want       *core.Sha256Sums
+		wantErr    bool
 	}{
 		{
-			name: "successfully retrieve SHASUMS file",
+			name:       "successfully retrieve SHASUMS file",
+			statusCode: http.StatusOK,
 			provider: &core.Provider{
 				Hostname:  "terraform.example.com",
 				Namespace: "hashicorp",
@@ -243,11 +245,24 @@ func Test_upstreamProviderRegistry_shaSums(t *testing.T) {
 				}(),
 			},
 		},
+		{
+			name:       "non-200 status code returns error",
+			statusCode: http.StatusNotFound,
+			provider: &core.Provider{
+				Hostname:  "terraform.example.com",
+				Namespace: "hashicorp",
+				Name:      "random",
+				Version:   "2.0.0",
+				OS:        "linux",
+				Arch:      "amd64",
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-				writer.WriteHeader(http.StatusOK)
+				writer.WriteHeader(tt.statusCode)
 				body := []byte(`5f9c7aa76b7c34d722fc9123208e26b22d60440cb47150dd04733b9b94f4541a  terraform-provider-random_2.0.0_linux_amd64.zip
 29df160b8b618227197cc9984c47412461ad66a300a8fc1db4052398bf5656ac  terraform-provider-random_2.0.0_linux_arm.zip`)
 				if _, err := writer.Write(body); err != nil {


### PR DESCRIPTION
## Summary

- Add HTTP status code check to `upstream.shaSums()` before parsing the response body — a non-200 response (e.g. 404, 500) was silently fed to `NewSha256Sums()`, causing cryptic parse errors instead of a clear error message
- Aligns with the existing pattern used in `copier.sha256Sums()` and `copier.sha256SumsSignature()`
- Adds a test case for non-200 responses