### PR TITLE
fix: check HTTP status and handle upload error in copier archive download

### DIFF
--- a/pkg/mirror/copier.go
+++ b/pkg/mirror/copier.go
@@ -76,9 +76,15 @@ func (c *copier) copy(provider *core.Provider) {
 		}
 	}()
 
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Error("failed to download provider archive", logKeyValues(provider), slog.Int("statusCode", resp.StatusCode))
+		return
+	}
+
 	fileName := provider.ArchiveFileName()
 	if err = c.storage.UploadMirroredFile(ctx, provider, fileName, resp.Body); err != nil {
 		c.logger.Error("failed to upload provider to mirror", logKeyValues(provider), slog.String("err", err.Error()))
+		return
 	}
 	c.logger.Info("successfully copied provider", logKeyValues(provider), slog.String("took", time.Since(begin).String()))
 }


### PR DESCRIPTION
## Summary

- Add HTTP status code check after downloading a provider archive from upstream — a non-200 response body (e.g. 404 error page) was silently uploaded and cached as the provider zip, permanently corrupting the mirror entry
- Add missing `return` after a failed `UploadMirroredFile` call, which previously fell through to log "successfully copied"
- Aligns with the existing pattern in `sha256Sums()` and `sha256SumsSignature()` in the same file