### PR TITLE
fix: rewrite mergeGPGPublicKeys to correctly merge signing keys

### DIFF
--- a/pkg/mirror/copier.go
+++ b/pkg/mirror/copier.go
@@ -183,14 +183,22 @@ func logKeyValues(provider *core.Provider) slog.Attr {
 }
 
 func mergeGPGPublicKeys(upstreamKeys, mirroredKeys []core.GPGPublicKey) ([]core.GPGPublicKey, bool) {
-	var merged []core.GPGPublicKey
+	// Start with all mirrored keys
+	merged := make([]core.GPGPublicKey, len(mirroredKeys))
+	copy(merged, mirroredKeys)
+
+	// Build a set of existing key IDs for fast lookup
+	existingKeyIDs := make(map[string]struct{}, len(mirroredKeys))
+	for _, key := range mirroredKeys {
+		existingKeyIDs[key.KeyID] = struct{}{}
+	}
+
+	// Append upstream keys that aren't already in the mirrored set
 	for _, upstreamKey := range upstreamKeys {
-		for _, storedKey := range mirroredKeys {
-			if storedKey.KeyID != upstreamKey.KeyID {
-				merged = append(merged, upstreamKey)
-			}
+		if _, exists := existingKeyIDs[upstreamKey.KeyID]; !exists {
+			merged = append(merged, upstreamKey)
 		}
 	}
 
-	return merged, len(merged) > len(upstreamKeys)
+	return merged, len(merged) > len(mirroredKeys)
 }

--- a/pkg/mirror/copier_test.go
+++ b/pkg/mirror/copier_test.go
@@ -274,3 +274,76 @@ func Test_copier_sha256Sums(t *testing.T) {
 		})
 	}
 }
+
+func Test_mergeGPGPublicKeys(t *testing.T) {
+	keyA := core.GPGPublicKey{KeyID: "AAA", ASCIIArmor: "armor-a"}
+	keyB := core.GPGPublicKey{KeyID: "BBB", ASCIIArmor: "armor-b"}
+	keyC := core.GPGPublicKey{KeyID: "CCC", ASCIIArmor: "armor-c"}
+
+	tests := []struct {
+		name            string
+		upstreamKeys    []core.GPGPublicKey
+		mirroredKeys    []core.GPGPublicKey
+		wantKeys        []core.GPGPublicKey
+		wantNeedsUpdate bool
+	}{
+		{
+			name:            "no keys on either side",
+			upstreamKeys:    nil,
+			mirroredKeys:    nil,
+			wantKeys:        []core.GPGPublicKey{},
+			wantNeedsUpdate: false,
+		},
+		{
+			name:            "upstream keys only, no mirrored keys",
+			upstreamKeys:    []core.GPGPublicKey{keyA, keyB},
+			mirroredKeys:    nil,
+			wantKeys:        []core.GPGPublicKey{keyA, keyB},
+			wantNeedsUpdate: true,
+		},
+		{
+			name:            "mirrored keys only, no upstream keys",
+			upstreamKeys:    nil,
+			mirroredKeys:    []core.GPGPublicKey{keyA},
+			wantKeys:        []core.GPGPublicKey{keyA},
+			wantNeedsUpdate: false,
+		},
+		{
+			name:            "identical keys on both sides",
+			upstreamKeys:    []core.GPGPublicKey{keyA, keyB},
+			mirroredKeys:    []core.GPGPublicKey{keyA, keyB},
+			wantKeys:        []core.GPGPublicKey{keyA, keyB},
+			wantNeedsUpdate: false,
+		},
+		{
+			name:            "upstream has new key not in mirror",
+			upstreamKeys:    []core.GPGPublicKey{keyA, keyC},
+			mirroredKeys:    []core.GPGPublicKey{keyA, keyB},
+			wantKeys:        []core.GPGPublicKey{keyA, keyB, keyC},
+			wantNeedsUpdate: true,
+		},
+		{
+			name:            "mirror has key rotated out of upstream",
+			upstreamKeys:    []core.GPGPublicKey{keyB},
+			mirroredKeys:    []core.GPGPublicKey{keyA, keyB},
+			wantKeys:        []core.GPGPublicKey{keyA, keyB},
+			wantNeedsUpdate: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, needsUpdate := mergeGPGPublicKeys(tt.upstreamKeys, tt.mirroredKeys)
+			if needsUpdate != tt.wantNeedsUpdate {
+				t.Errorf("mergeGPGPublicKeys() needsUpdate = %v, want %v", needsUpdate, tt.wantNeedsUpdate)
+			}
+			if len(got) != len(tt.wantKeys) {
+				t.Fatalf("mergeGPGPublicKeys() returned %d keys, want %d", len(got), len(tt.wantKeys))
+			}
+			for i, key := range got {
+				if key.KeyID != tt.wantKeys[i].KeyID {
+					t.Errorf("mergeGPGPublicKeys()[%d].KeyID = %s, want %s", i, key.KeyID, tt.wantKeys[i].KeyID)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Rewrite `mergeGPGPublicKeys` which had three compounding bugs: cartesian product duplication from nested loops, dropping all previously-mirrored keys on every sync, and a meaningless `needsUpdate` return value
- New logic: start with mirrored keys, add upstream keys not already present (by KeyID), return whether any were added
- Add unit tests covering empty inputs, disjoint sets, overlapping keys, and key rotation scenarios