### PR TITLE
feat(auth): add --auth-oidc-audience flag to override client-id

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -66,6 +66,7 @@ var (
 	flagAuthOidcClientId string
 	flagAuthOidcScopes   []string
 	flagAuthOidcAuthURL  string
+	flagAuthOidcAudience string
 
 	// Okta auth
 	flagAuthOktaIssuer   string
@@ -214,6 +215,7 @@ func init() {
 	serverCmd.Flags().StringVar(&flagAuthOidcClientId, "auth-oidc-clientid", "", "OIDC client identifier")
 	serverCmd.Flags().StringSliceVar(&flagAuthOidcScopes, "auth-oidc-scopes", nil, "List of OAuth2 scopes")
 	serverCmd.Flags().StringVar(&flagAuthOidcAuthURL, "auth-oidc-auth-url", "", "Override the OIDC authorization URL returned in .well-known/terraform.json. Defaults to the URL from OIDC discovery")
+	serverCmd.Flags().StringVar(&flagAuthOidcAudience, "auth-oidc-audience", "", "Override the expected audience (aud) claim for JWT verification. Defaults to --auth-oidc-clientid")
 
 	// Terraform Login Protocol options.
 	serverCmd.Flags().StringVar(&flagAuthOktaClientId, "login-client", "", "The client_id value to use when making requests")
@@ -307,7 +309,7 @@ func setupOidc(ctx context.Context) (auth.Provider, *discovery.LoginV1, error) {
 		slog.Any("scopes", flagAuthOidcScopes),
 	)
 
-	provider, err := auth.NewOidcProvider(authCtx, flagAuthOidcIssuer, flagAuthOidcClientId)
+	provider, err := auth.NewOidcProvider(authCtx, flagAuthOidcIssuer, flagAuthOidcClientId, flagAuthOidcAudience)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to set up oidc provider: %w", err)
 	}

--- a/docs/configuration/authentication/oidc.md
+++ b/docs/configuration/authentication/oidc.md
@@ -21,6 +21,7 @@ The following configuration options are available:
 |`--auth-oidc-issuer`|`BORING_REGISTRY_AUTH_OIDC_ISSUER`|OIDC issuer URL|
 |`--auth-oidc-scopes`|`BORING_REGISTRY_AUTH_OIDC_SCOPES`|List of OAuth2 scopes|
 |`--auth-oidc-auth-url`|`BORING_REGISTRY_AUTH_OIDC_AUTH_URL`|Override the OIDC authorization URL returned in `.well-known/terraform.json`. Defaults to the URL from OIDC discovery|
+|`--auth-oidc-audience`|`BORING_REGISTRY_AUTH_OIDC_AUDIENCE`|Override the expected audience (`aud`) claim for JWT verification. Defaults to `--auth-oidc-clientid`|
 |`--login-grant-types`|`BORING_REGISTRY_LOGIN_GRANT_TYPES`|An array describing a set of OAuth 2.0 grant types (default `[authz_code]`)|
 |`--login-ports`|`BORING_REGISTRY_LOGIN_PORTS`|Inclusive range of TCP ports that the Terraform/OpenTofu CLI may use (default `[10000,10010]`)|
 

--- a/pkg/auth/provider_oidc.go
+++ b/pkg/auth/provider_oidc.go
@@ -12,6 +12,7 @@ type OidcProvider struct {
 	logger           *slog.Logger
 	issuer           string
 	clientIdentifier string
+	audience         string
 	provider         *oidc.Provider
 }
 
@@ -20,8 +21,16 @@ func (p *OidcProvider) String() string { return "oidc" }
 // Unfortunately, it's difficult to write tests for this method, as we would need an OIDC Authorization Server
 // to generate valid signed JWTs
 func (o *OidcProvider) Verify(ctx context.Context, token string) error {
+	// The go-oidc library uses Config.ClientID to verify the "aud" claim in the JWT.
+	// Some identity providers (e.g. Okta without API Access Management) issue tokens where "aud" doesn't match the OIDC client ID.
+	// When an explicit audience is configured, we use it instead of the client ID for audience verification.
+	expectedAudience := o.clientIdentifier
+	if o.audience != "" {
+		expectedAudience = o.audience
+	}
+
 	oidcConfig := &oidc.Config{
-		ClientID: o.clientIdentifier,
+		ClientID: expectedAudience,
 	}
 	verifier := o.provider.VerifierContext(ctx, oidcConfig)
 
@@ -39,7 +48,7 @@ func (o *OidcProvider) TokenURL() string {
 	return o.provider.Endpoint().TokenURL
 }
 
-func NewOidcProvider(ctx context.Context, issuer, clientIdentifier string) (*OidcProvider, error) {
+func NewOidcProvider(ctx context.Context, issuer, clientIdentifier, audience string) (*OidcProvider, error) {
 	logger := slog.Default()
 	start := time.Now()
 	provider, err := oidc.NewProvider(ctx, issuer)
@@ -53,6 +62,7 @@ func NewOidcProvider(ctx context.Context, issuer, clientIdentifier string) (*Oid
 		logger:           logger,
 		issuer:           issuer,
 		clientIdentifier: clientIdentifier,
+		audience:         audience,
 		provider:         provider,
 	}, nil
 }

--- a/pkg/auth/provider_oidc_test.go
+++ b/pkg/auth/provider_oidc_test.go
@@ -35,7 +35,7 @@ func TestOidcProviderDiscovery(t *testing.T) {
 	defer s.Close()
 	issuer = s.URL
 
-	provider, err := NewOidcProvider(context.Background(), issuer, "boring-registry")
+	provider, err := NewOidcProvider(context.Background(), issuer, "boring-registry", "")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, provider.AuthURL())
 	assert.NotEmpty(t, provider.TokenURL())


### PR DESCRIPTION
This PR implements a feature proposed in https://github.com/boring-registry/boring-registry/issues/343 which allows overriding the audience claim.