### PR TITLE
refactor(golangci-lint): manage installation through pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,6 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.11.4
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,11 @@ repos:
       - id: go-fmt
         args: [-w]
       - id: go-vet-mod
-      - id: golangci-lint-mod
-        args: [--build-tags=integration]
       - id: go-mod-tidy
       - id: go-test-mod
         args: [-v]
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.12.2
+    hooks:
+      - id: golangci-lint
+        args: [--build-tags=integration]


### PR DESCRIPTION
Before this change, contributors had to manage the golangci-lint version externally. I'd like to manage it through pre-commit, so that we run the same version locally as well as in CI