### PR TITLE
fix(mirror): accept the Authorization header on the provider archive endpoint

### DIFF
--- a/pkg/mirror/transport.go
+++ b/pkg/mirror/transport.go
@@ -62,7 +62,11 @@ func MakeHandler(svc Service, auth endpoint.Middleware, metrics *o11y.MirrorMetr
 		),
 	)
 
-	// If static auth is
+	// The archive download accepts the token from either the Authorization header or the
+	// `token` query parameter. The header is the usual way to authenticate and is all the
+	// endpoints above accept, but the archive URLs handed out by addAuthToken carry the
+	// token as a query parameter, so both have to work here. The query parameter is applied
+	// last so that it keeps taking precedence when a request supplies both.
 	r.Methods("GET").Path(`/{hostname}/{namespace}/{name}/terraform-provider-{nameplaceholder}_{version}_{os}_{architecture}.zip`).Handler(
 		instrumentation.WrapHandler(
 			httptransport.NewServer(
@@ -72,6 +76,7 @@ func MakeHandler(svc Service, auth endpoint.Middleware, metrics *o11y.MirrorMetr
 				append(
 					options,
 					httptransport.ServerBefore(extractMuxVars(varHostname, varNamespace, varName, varVersion, varOS, varArchitecture)),
+					httptransport.ServerBefore(jwt.HTTPToContext()),
 					httptransport.ServerBefore(tokenQueryParamToContext()),
 				)...,
 			),

--- a/pkg/mirror/transport_test.go
+++ b/pkg/mirror/transport_test.go
@@ -1,0 +1,114 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/boring-registry/boring-registry/pkg/auth"
+	"github.com/boring-registry/boring-registry/pkg/core"
+	o11y "github.com/boring-registry/boring-registry/pkg/observability"
+
+	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const stubArchiveLocation = "https://example.com/terraform-provider-null_3.3.0_linux_amd64.zip"
+
+// archiveOnlyService implements Service, but only serves the provider archive endpoint.
+type archiveOnlyService struct{}
+
+func (s *archiveOnlyService) ListProviderVersions(_ context.Context, _ *core.Provider) (*ListProviderVersionsResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *archiveOnlyService) ListProviderInstallation(_ context.Context, _ *core.Provider) (*ListProviderInstallationResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *archiveOnlyService) RetrieveProviderArchive(_ context.Context, _ *core.Provider) (*retrieveProviderArchiveResponse, error) {
+	return &retrieveProviderArchiveResponse{
+		location:     stubArchiveLocation,
+		mirrorSource: mirrorSource{isMirror: true},
+	}, nil
+}
+
+// TestRetrieveProviderArchiveAuthentication asserts that the provider archive endpoint accepts
+// the token from either the Authorization header or the `token` query parameter.
+func TestRetrieveProviderArchiveAuthentication(t *testing.T) {
+	t.Parallel()
+
+	const (
+		token = "very-secure-token"
+		path  = "/registry.terraform.io/hashicorp/null/terraform-provider-null_3.3.0_linux_amd64.zip"
+	)
+
+	metrics := o11y.NewMetrics([]float64{1})
+	handler := MakeHandler(
+		&archiveOnlyService{},
+		auth.Middleware(auth.NewStaticProvider(token)),
+		metrics.Mirror,
+		o11y.NewMiddleware(metrics.Http),
+		httptransport.ServerErrorEncoder(ErrorEncoder),
+	)
+
+	testCases := []struct {
+		name           string
+		authorization  string
+		query          string
+		wantStatusCode int
+	}{
+		{
+			name:           "token in the Authorization header",
+			authorization:  "Bearer " + token,
+			wantStatusCode: http.StatusTemporaryRedirect,
+		},
+		{
+			name:           "token in the query parameter",
+			query:          "?token=" + token,
+			wantStatusCode: http.StatusTemporaryRedirect,
+		},
+		{
+			name:           "token in both the Authorization header and the query parameter",
+			authorization:  "Bearer " + token,
+			query:          "?token=" + token,
+			wantStatusCode: http.StatusTemporaryRedirect,
+		},
+		{
+			name:           "no token",
+			wantStatusCode: http.StatusUnauthorized,
+		},
+		{
+			name:           "invalid token in the Authorization header",
+			authorization:  "Bearer invalid",
+			wantStatusCode: http.StatusUnauthorized,
+		},
+		{
+			name:           "invalid token in the query parameter",
+			query:          "?token=invalid",
+			wantStatusCode: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, path+tc.query, nil)
+			if tc.authorization != "" {
+				req.Header.Set("Authorization", tc.authorization)
+			}
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, req)
+
+			require.Equal(t, tc.wantStatusCode, recorder.Code)
+			if tc.wantStatusCode == http.StatusTemporaryRedirect {
+				assert.Equal(t, stubArchiveLocation, recorder.Header().Get("Location"))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The provider archive endpoint of the network mirror is the only endpoint that does not accept
the token from the `Authorization` header. `index.json` and `<version>.json` both register
`jwt.HTTPToContext`, but the archive route registers only `tokenQueryParamToContext`, so a
client that authenticates the way every other endpoint expects gets:

```
401 {"errors":["unauthorized: request does not contain a token"]}
```

That is why `addAuthToken` has to append the token to the archive URLs the mirror hands out.
It ties authenticating the download to the URL it was advertised at, rather than to the
credentials on the request.

## Change

Register `jwt.HTTPToContext()` on the archive endpoint alongside the existing
`tokenQueryParamToContext()`.

`jwt.HTTPToContext` is a no-op when the header is missing or malformed, and the query
parameter is applied last, so it keeps taking precedence when a request supplies both.
Existing clients, including anything using the URLs from `addAuthToken`, are unaffected. This
only adds a second, already conventional way to authenticate the same request.

## How I ran into this, and what this change does not fix

We run boring-registry as a pull-through mirror (`--network-mirror-pull-through=true`) with
`--auth-static-token`. Plain terraform and tofu work fine. With
[Terragrunt's provider cache](https://terragrunt.gruntwork.io/docs/features/provider-cache-server/)
(`--provider-cache`), every provider fails to download:

```
ERROR Fetching provider registry.terraform.io/hashicorp/null v3.3.0 returned an error:
404 Not Found returned from https://registry.example.com/v1/mirror/registry.terraform.io/hashicorp/null/terraform-provider-null_3.3.0_darwin_arm64.zip%3Ftoken=<token>
```

In pull-through mode `mergePlatforms` advertises the archive as a relative URL with the token
in a query string, and `ListProviderInstallation` takes that branch whenever the upstream
registry is reachable, so it applies to essentially every request. Terragrunt's cache server
resolves that relative reference by pushing the whole string through `url.URL.Path`, so Go
escapes the `?` and the download asks for a path that does not exist. The escaping is
Terragrunt's bug, not this project's.

I want to be upfront that this change alone does not fix Terragrunt: the escaped path matches
no route, so it 404s in the router before authentication is attempted. I measured the
combinations locally, running real `terragrunt init --provider-cache` (v0.77.22) against a
mirror that emulates this protocol, including routing on the raw path:

| emulated server behaviour | archive URL advertised | header accepted | `terragrunt init` |
|---|---|---|---|
| upstream today | relative, `?token=<token>` | no | fails, 404 x6 (initial plus 5 retries) |
| this PR alone | relative, `?token=<token>` | yes | still fails, 404 x6 |
| this PR, and no token in the URL | relative, no token | yes | succeeds, single 200, authenticated by header |
| absolute URL, nothing else changed | absolute, `?token=<token>` | no | succeeds, single 200 |

What this PR contributes is decoupling the archive download from the URL it was advertised at.
Terragrunt already sends the configured credentials as an `Authorization: Bearer` header on
that same request (`ProviderCache.newRequest` via `credsSource.ForHost`); the fake mirror
observed the header on every request, including the ones it answered with a 404. So once the
header is honoured, the download can be authenticated on its own merits. That is what makes a
path rewrite usable as a workaround in the meantime, and it is the prerequisite for not
embedding the token at all.

## A backwards compatible fix for the Terragrunt case, separate from this PR

The last row above is worth calling out, because it fixes the Terragrunt case without changing
authentication at all and without any wire level break. Advertising the archive as an absolute
URL keeps the token exactly where it is, keeps query parameter auth working, and keeps working
for any client that uses the advertised URL verbatim. Terragrunt short circuits on absolute
URLs in both the version we hit this with and current main, so nothing gets escaped:

```go
if strings.Contains(link, "://") {
    return link
}
```

Absolute URLs are already a shape this codebase emits: `toListProviderInstallationResponse`
returns `p.DownloadURL`, which for the GCS backend is a signed URL on another host entirely,
and terraform consumes that today. Root relative URLs are not a substitute, I checked: current
Terragrunt puts those into `url.URL.Path` as well, so the `?` is still escaped.

The one cost is that the server has to know its external base URL. `PopulateRequestContext` is
already registered for the mirror handler, so `ContextKeyRequestHost` is available in the
encoder, and the scheme could come from a flag or from `X-Forwarded-Proto` for deployments
that terminate TLS upstream.

I am happy to open that as a separate PR if you would like it, and to keep this one scoped to
the authentication inconsistency.

## Tests

Adds `pkg/mirror/transport_test.go`, a table test over `MakeHandler` covering the archive
endpoint with the token in the header, in the query parameter, in both, absent, and invalid in
either position.

Without the one line change, exactly one case fails, with the same status seen in production:

```
--- FAIL: TestRetrieveProviderArchiveAuthentication/token_in_the_Authorization_header
    Error:      Not equal:
                expected: 307
                actual  : 401
```

`gofmt`, `go vet ./pkg/...`, `go mod tidy` (no change), `go test ./...` and
`golangci-lint run --build-tags=integration` are all clean.

## Follow-up

With the header accepted, `addAuthToken` could stop embedding the token in archive URLs. That
would keep credentials out of client logs and error messages, where they are visible today
(the token appears in the 404 quoted above). It is a behaviour change for any client that
relies on the advertised URL carrying credentials, so I left it out. Terraform, OpenTofu and
Terragrunt all send the configured credentials for the host, so they would be unaffected.
Happy to add it here, as a separate PR, or behind a flag, whichever you prefer.
